### PR TITLE
Fix navigation bar color on HyperOS

### DIFF
--- a/app/src/main/java/com/rosan/installer/ui/theme/InstallerTheme.kt
+++ b/app/src/main/java/com/rosan/installer/ui/theme/InstallerTheme.kt
@@ -1,6 +1,8 @@
 package com.rosan.installer.ui.theme
 
+import android.app.Activity
 import android.os.Build
+import android.view.View
 import androidx.activity.ComponentActivity
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -55,9 +57,27 @@ fun InstallerTheme(
         }
     }
 
+    DisableNavigationBarContrast(view)
+
     MaterialTheme(
         colorScheme = colorScheme,
         typography = Typography,
         content = content
     )
+}
+
+/**
+ * Disable navigation bar contrast enforcement.
+ * This is useful for devices where the navigation bar color should not be enforced
+ * to match the system theme, allowing for custom colors.
+ */
+@Composable
+fun DisableNavigationBarContrast(view: View) {
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            window.isNavigationBarContrastEnforced = false
+        }
+    }
 }

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Installer" parent="Theme.Material3.DayNight" />
+    <style name="Theme.Installer" parent="Theme.Material3.DayNight">
+        <!--    Compat Navigation Bar Color when ModalBottomSheet activated    -->
+        <item name="android:enforceNavigationBarContrast">false</item>
+    </style>
 
     <style name="Theme.Installer.Translucent" parent="Theme.Installer">
         <item name="android:windowIsTranslucent">true</item>


### PR DESCRIPTION
The full-screen gestures in HyperOS are based on the original three-button navigation system. Therefore, immersive adaptation should be performed for button navigation, not gesture navigation.