### PR TITLE
feat(installer): 确保定制UI中安装成功后能打开目标应用

### DIFF
--- a/app/src/main/aidl/com/rosan/installer/IPrivilegedService.aidl
+++ b/app/src/main/aidl/com/rosan/installer/IPrivilegedService.aidl
@@ -6,4 +6,14 @@ interface IPrivilegedService {
     void delete(in String[] paths);
 
     void setDefaultInstaller(in ComponentName component, boolean enable);
+
+    /**
+     * 执行命令
+     */
+    String execLine(String command);
+
+    /**
+     * 执行数组中分离的命令
+     */
+    String execArr(in String[] command);
 }

--- a/app/src/main/java/com/rosan/installer/ui/page/installer/dialog/inner/InstallSuccessDialog.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/installer/dialog/inner/InstallSuccessDialog.kt
@@ -79,7 +79,6 @@ fun installSuccessDialog( // 小写开头
         buttons = DialogButtons(
             DialogParamsType.InstallerInstallSuccess.id
         ) {
-            installer.config.authorizer
             val list = mutableListOf<DialogButton>()
             val intent =
                 if (packageName.isNotEmpty()) context.packageManager.getLaunchIntentForPackage(


### PR DESCRIPTION
## 变更说明

- 增强Shizuku的`UserService`，新增`ExecArr`与`ExecLine`两个方法。
  前者可以以完整的shell环境执行命令，后者只支持单条命令，不支持管道符。
  这个机制带来了运行时的shell命令执行能力。

- 新增feature：解决了一些定制系统上使用 `DialogInstall` 时，过早 `Close` 自己导致用户点击系统的链式启动确认框后无法打开应用。现在InstallerX会智能地检测用户是否 **真正地** 打开了目标软件，在确认打开以后，才会 `Close` 掉自己。目前设置的超时是10秒。

### 可用性

- 目前仅在Shizuku上测试过可用性，下列系统确认可用
  - OneUI 7.0 (Android 15)
  - HyperOS 2.0.200 (Android 15)