### PR TITLE
feat: enhance logging and error handling in DhizukuPrivilegedService 

### DIFF
--- a/app/src/main/java/com/rosan/installer/data/recycle/model/entity/DhizukuPrivilegedService.kt
+++ b/app/src/main/java/com/rosan/installer/data/recycle/model/entity/DhizukuPrivilegedService.kt
@@ -3,11 +3,10 @@ package com.rosan.installer.data.recycle.model.entity
 import android.app.admin.DevicePolicyManager
 import android.content.ComponentName
 import android.content.Context
-import android.os.RemoteException
 import com.rosan.dhizuku.api.Dhizuku
 import com.rosan.installer.data.recycle.util.InstallIntentFilter
 import com.rosan.installer.data.recycle.util.delete
-import java.io.IOException
+import timber.log.Timber
 
 class DhizukuPrivilegedService : BasePrivilegedService() {
     private val devicePolicyManager: DevicePolicyManager =
@@ -16,68 +15,38 @@ class DhizukuPrivilegedService : BasePrivilegedService() {
     override fun delete(paths: Array<out String>) = paths.delete()
 
     override fun setDefaultInstaller(component: ComponentName, enable: Boolean) {
-        devicePolicyManager.clearPackagePersistentPreferredActivities(
-            // TODO
-            // DhizukuVariables.PARAM_COMPONENT
-            Dhizuku.getOwnerComponent(),
-            component.packageName
-        )
-        if (!enable) return
-        devicePolicyManager.addPersistentPreferredActivity(
-            // TODO
-            // DhizukuVariables.PARAM_COMPONENT,
-            Dhizuku.getOwnerComponent(),
-            InstallIntentFilter, component
-        )
+        try {
+            val ownerComponent = Dhizuku.getOwnerComponent()
+
+            // 可以在这里添加日志，检查 ownerComponent 是否为 null
+            Timber.tag("DhizukuPrivilegedService").d("Owner component: $ownerComponent")
+
+            devicePolicyManager.clearPackagePersistentPreferredActivities(
+                ownerComponent,
+                component.packageName
+            )
+            if (!enable) return
+            devicePolicyManager.addPersistentPreferredActivity(
+                ownerComponent,
+                InstallIntentFilter, component
+            )
+        } catch (t: Throwable) { // <--- 使用 Throwable 来捕获包括 Error 在内的所有问题
+            // 捕获所有异常，防止进程崩溃
+            Timber.tag("DhizukuPrivilegedService")
+                .e(t, "Failed to set default installer due to a throwable")
+            // 重新抛出，让客户端知道操作失败了
+            throw t
+        }
     }
 
-    @Throws(RemoteException::class)
     override fun execLine(command: String): String {
-        return try {
-            // 执行 shell 命令
-            val process = Runtime.getRuntime().exec(command)
-            // 读取执行结果
-            readResult(process)
-        } catch (e: IOException) {
-            // 将 IOException 包装成 RemoteException 抛出
-            throw RemoteException(e.message)
-        } catch (e: InterruptedException) {
-            // 恢复线程的中断状态
-            Thread.currentThread().interrupt()
-            // 将 InterruptedException 包装成 RemoteException 抛出
-            throw RemoteException(e.message)
-        }
+        // Device Owner Privileged Service does not support shell access
+        throw UnsupportedOperationException("Not supported in DhizukuPrivilegedService")
     }
 
-    @Throws(RemoteException::class)
+
     override fun execArr(command: Array<String>): String {
-        return try {
-            // 执行 shell 命令
-            val process = Runtime.getRuntime().exec(command)
-            // 读取执行结果
-            readResult(process)
-        } catch (e: IOException) {
-            // 将 IOException 包装成 RemoteException 抛出
-            throw RemoteException(e.message)
-        } catch (e: InterruptedException) {
-            // 恢复线程的中断状态
-            Thread.currentThread().interrupt()
-            // 将 InterruptedException 包装成 RemoteException 抛出
-            throw RemoteException(e.message)
-        }
-    }
-
-    /**
-     * 读取执行结果，利用 Kotlin 的扩展函数简化代码。
-     * 如果有异常会向上抛出。
-     */
-    @Throws(IOException::class, InterruptedException::class)
-    private fun readResult(process: Process): String {
-        // 使用 'use' 块可以自动关闭流，更安全、简洁
-        val output = process.inputStream.bufferedReader().use { reader ->
-            reader.readText()
-        }
-        process.waitFor()
-        return output
+        // Device Owner Privileged Service does not support shell access
+        throw UnsupportedOperationException("Not supported in DhizukuPrivilegedService")
     }
 }

--- a/app/src/main/java/com/rosan/installer/data/recycle/model/impl/DhizukuUserServiceRecycler.kt
+++ b/app/src/main/java/com/rosan/installer/data/recycle/model/impl/DhizukuUserServiceRecycler.kt
@@ -10,8 +10,8 @@ import com.rosan.dhizuku.api.DhizukuUserServiceArgs
 import com.rosan.installer.IDhizukuUserService
 import com.rosan.installer.IPrivilegedService
 import com.rosan.installer.data.recycle.model.entity.DhizukuPrivilegedService
-import com.rosan.installer.data.recycle.repo.recyclable.UserService
 import com.rosan.installer.data.recycle.repo.Recycler
+import com.rosan.installer.data.recycle.repo.recyclable.UserService
 import com.rosan.installer.data.recycle.util.requireDhizukuPermissionGranted
 import com.rosan.installer.di.init.processModules
 import kotlinx.coroutines.channels.awaitClose
@@ -22,6 +22,7 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.koin.core.context.startKoin
+import timber.log.Timber
 
 object DhizukuUserServiceRecycler : Recycler<DhizukuUserServiceRecycler.UserServiceProxy>(),
     KoinComponent {
@@ -38,6 +39,14 @@ object DhizukuUserServiceRecycler : Recycler<DhizukuUserServiceRecycler.UserServ
 
     class DhizukuUserService @Keep constructor(context: Context) : IDhizukuUserService.Stub() {
         init {
+            // 在远程服务进程中，必须首先初始化 Dhizuku API。
+            // 否则会导致AssertionError
+            if (!Dhizuku.init(context)) {
+                // 在此处记录日志，因为初始化失败将导致所有后续操作失败。
+                // 也可以选择抛出一个异常来提前终止。
+                Timber.tag("DhizukuUserService")
+                    .e("CRITICAL: Dhizuku.init() failed in remote process!")
+            }
             startKoin {
                 modules(processModules)
                 androidContext(context)

--- a/app/src/main/java/com/rosan/installer/ui/page/installer/dialog/inner/InstallSuccessDialog.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/installer/dialog/inner/InstallSuccessDialog.kt
@@ -34,6 +34,7 @@ import com.rosan.installer.ui.page.installer.dialog.DialogParams
 import com.rosan.installer.ui.page.installer.dialog.DialogParamsType
 import com.rosan.installer.ui.page.installer.dialog.DialogViewAction
 import com.rosan.installer.ui.page.installer.dialog.DialogViewModel
+import com.rosan.installer.util.toast
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -93,6 +94,24 @@ fun installSuccessDialog( // 小写开头
                                 "App $packageName is in foreground, closing dialog."
                             )
                             viewModel.dispatch(DialogViewAction.Close)
+                        } else {
+                            // Explicitly handle the case where the app is not in the foreground
+                            // or the check timed out. This makes the logic clearer.
+                            if (installer.config.authorizer == ConfigEntity.Authorizer.Dhizuku) {
+                                Timber.tag("InstallSuccessDialog").d(
+                                    "Dhizuku expected, closing dialog."
+                                )
+                            } else {
+                                Timber.tag("InstallSuccessDialog").d(
+                                    "App $packageName not detected in foreground after 10 seconds. Dialog will close itself."
+                                )
+                                withContext(Dispatchers.Main) {
+                                    context.toast("等待应用启动超时，自动关闭安装窗口。")
+                                }
+                            }
+                            // ALWAYS close the dialog afterwards, regardless of whether the app
+                            // was detected in the foreground or the check timed out.
+                            viewModel.dispatch(DialogViewAction.Close)
                         }
                     }
                 })
@@ -122,26 +141,35 @@ private suspend fun isAppInForeground(
     config: ConfigEntity
 ): Boolean {
     // Use withTimeoutOrNull to limit the execution time to 10 seconds
-    val result = withTimeoutOrNull(10000L) {
-        while (true) {
-            // Execute the function in IO thread
-            val topApp = withContext(Dispatchers.IO) {
-                // Call the function to get the top app package name
-                getTopApp(config)
+    val result =
+        withTimeoutOrNull(10000L) {
+            while (true) {
+                // Execute the function in IO thread
+                val topApp = withContext(Dispatchers.IO) {
+                    // Call the function to get the top app package name
+                    getTopApp(config)
+                }
+
+                Timber.tag("isAppInForeground").d("Checking foreground app: $topApp")
+
+                if (topApp == targetPackageName) {
+                    Timber.tag("isAppInForeground")
+                        .d("Target App $targetPackageName is in foreground.")
+                    return@withTimeoutOrNull true
+                }
+
+                delay(1000L) // Perform a check every 1 second
             }
 
-            Timber.tag("isAppInForeground").d("Checking foreground app: $topApp")
-
-            if (topApp == targetPackageName) {
-                Timber.tag("isAppInForeground").d("Target App $targetPackageName is in foreground.")
-                return@withTimeoutOrNull true
+            if (config.authorizer == ConfigEntity.Authorizer.Dhizuku) {
+                Timber.tag("isAppInForeground").d("Dhizuku detected, false as default.")
+            } else {
+                Timber.tag("isAppInForeground")
+                    .d("Target App $targetPackageName not found in foreground, timing out.")
             }
 
-            delay(500L) // Perform a check every 500 milliseconds
+            false
         }
-        @Suppress("UNREACHABLE_CODE")
-        false
-    }
     return result == true // Return true if the app was found in foreground, false if timed out
 }
 
@@ -151,6 +179,7 @@ private suspend fun isAppInForeground(
  * @param config 用于执行高权限Shell命令的配置实体。
  * @return 当前前台应用的包名，如果无法获取则返回空字符串。
  */
+// TODO 使用 UsageStatsManager API 来替代 dumpsys 命令。
 private fun getTopApp(
     config: ConfigEntity
 ): String {
@@ -162,8 +191,9 @@ private fun getTopApp(
             /**
              * Exec `dumpsys` command to get the current focused window.
              * This command is unstable and may change in future Android versions.
-             * Tested on OneUI 7.0 (Android 15)
-             * Tested on HyperOS 2.0.200 (Android 15)
+             * Tested by Shizuku:
+             *  Tested on OneUI 7.0 (Android 15)
+             *  Tested on HyperOS 2.0.200 (Android 15)
              */
             val command = "dumpsys window | grep mCurrentFocus"
             // in order to use shell environment, we need to use execArr
@@ -171,7 +201,8 @@ private fun getTopApp(
             val cmdArray = arrayOf("/system/bin/sh", "-c", command)
             // Call the interface method via userService.privileged
             val result = userService.privileged.execArr(cmdArray)
-            Timber.d("Result of executing '$cmdArray': $result")
+            Timber.tag("getTopApp")
+                .d("Result of executing '${cmdArray.contentToString()}': $result")
 
             topAppPackage = if (result.isBlank()) {
                 // Result is empty, return empty string
@@ -181,13 +212,16 @@ private fun getTopApp(
                 val componentPart = result.split(' ').lastOrNull { it.contains('/') }
                 componentPart?.substringBefore('/') ?: ""
             }
+        } catch (_: UnsupportedOperationException) {
+            Timber.tag("getTopApp")
+                .d("Authorizer does not support shell access, returning empty string")
         } catch (e: Exception) {
-            Timber.e(e, "Exception while getting top app package")
+            Timber.tag("getTopApp").e(e, "Exception while getting top app package")
             // return empty string if any exception occurs
             topAppPackage = ""
         }
     }
     // Return the package name of the top app extracted in the lambda
-    Timber.d("Acquired Top App Package Name: $topAppPackage")
+    Timber.tag("getTopApp").d("Acquired Top App Package Name: $topAppPackage")
     return topAppPackage
 }


### PR DESCRIPTION
## 逻辑更新

当用户从DialogInstall点击打开时，协程会启动一个10s倒计时，每秒判定是否已经 **真正地** 打开了目标app，如果10s超时未打开，则弹出一个toast告知用户并Close掉自己

对于Dhizuku，其无法调用shell执行命令，因此10s后将直接超时，静默地将自己清理掉，这种情况不会弹出任何提示

## 修复
fix #43 Comment “Dhizuku无法锁定安装器”，AVD SDK30以及MIUI 14测试可用