### PR TITLE
fix: DhizukuPriviligedService choice path, feat: shell based remove for shizuku & root

### DIFF
--- a/app/src/main/java/com/rosan/installer/data/app/model/impl/installer/IBinderInstallerRepoImpl.kt
+++ b/app/src/main/java/com/rosan/installer/data/app/model/impl/installer/IBinderInstallerRepoImpl.kt
@@ -252,9 +252,6 @@ abstract class IBinderInstallerRepoImpl : InstallerRepo, KoinComponent {
     ) {
         fun special() = null
         val authorizer = config.authorizer
-        Timber.tag("useUserService").d(
-            "useUserService: authorizer=$authorizer, entities=${entities.sourcePath()}"
-        )
         useUserService(
             config, if (authorizer == ConfigEntity.Authorizer.None
                 || authorizer == ConfigEntity.Authorizer.Dhizuku

--- a/app/src/main/java/com/rosan/installer/data/recycle/model/entity/DhizukuPrivilegedService.kt
+++ b/app/src/main/java/com/rosan/installer/data/recycle/model/entity/DhizukuPrivilegedService.kt
@@ -4,16 +4,15 @@ import android.app.admin.DevicePolicyManager
 import android.content.ComponentName
 import android.content.Context
 import com.rosan.dhizuku.api.Dhizuku
-import com.rosan.dhizuku.shared.DhizukuVariables
 import com.rosan.installer.data.recycle.util.InstallIntentFilter
-import com.rosan.installer.data.recycle.util.delete
+import com.rosan.installer.data.recycle.util.deletePaths
 import timber.log.Timber
 
 class DhizukuPrivilegedService : BasePrivilegedService() {
     private val devicePolicyManager: DevicePolicyManager =
         context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
 
-    override fun delete(paths: Array<out String>) = paths.delete()
+    override fun delete(paths: Array<out String>) = deletePaths(paths)
 
     override fun setDefaultInstaller(component: ComponentName, enable: Boolean) {
         try {

--- a/app/src/main/java/com/rosan/installer/data/recycle/util/PrivilegedUtil.kt
+++ b/app/src/main/java/com/rosan/installer/data/recycle/util/PrivilegedUtil.kt
@@ -3,19 +3,22 @@ package com.rosan.installer.data.recycle.util
 import android.content.ContentResolver
 import android.content.Intent
 import android.content.IntentFilter
-import timber.log.Timber
+import android.util.Log
 import java.io.File
 
-fun Array<out String>.delete() {
-    for (path in this) {
-        Timber.tag("DELETE_PATH").d("path: $path")
-        val file = File(
-            if (path.startsWith("/mnt/user/0/emulated/0")) {
-                path.replace("/mnt/user/0/emulated/0", "/storage/emulated/0")
-            } else path
-        )
-        Timber.tag("DELETE_PATH").d("file: $file")
-        if (file.exists()) file.delete()
+// Privileged Process is not Main Process, so we use Log.d instead of Timber
+@Suppress("LogNotTimber")
+fun deletePaths(paths: Array<out String>) {
+    for (path in paths) {
+        Log.d("DELETE_PATH", "path: $path")
+        println("Deleting path: $path")
+        val file = File(path)
+        Log.d("DELETE_PATH", "file: $file")
+        if (file.exists()) {
+            Log.d("DELETE_PATH", "Deleting file: $file")
+            println("Deleting file: $file")
+            file.delete()
+        }
     }
 }
 


### PR DESCRIPTION
## Important Notice
Since this commit, Dhizuku only guarantee availability on AOSP-based / SDK 34 or higher
I can't fix the problem I have came across on SDK 30

Features affected: 
- set default installer
- auto delete after installation

Fully tested on
- AVD SDK 36
  - Shizuku
    - Set Default Installer OK
    - Install APK                OK
    - Auto Delete APK      OK
  - Dhizuku
    - Set Default Installer OK
    - Install APK                OK
    - Auto Delete APK      OK
- AVD SDK 34
  - Shizuku
    - Set Default Installer OK
    - Install APK                OK
    - Auto Delete APK      OK
  - Dhizuku
    - Set Default Installer OK
    - Install APK                OK
    - Auto Delete APK      OK
- AVD SDK 30
  - Shizuku
    - Set Default Installer OK
    - Install APK                OK
    - Auto Delete APK      OK
  - Dhizuku
    - Set Default Installer **FAIL**
    - Install APK                OK
    - Auto Delete APK      **FAIL**