### PR TITLE
feat: improve split APK name display and add translations

### DIFF
--- a/app/src/main/java/com/rosan/installer/ui/page/installer/dialog/inner/InstallChoiceDialog.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/installer/dialog/inner/InstallChoiceDialog.kt
@@ -51,6 +51,7 @@ import com.rosan.installer.ui.page.installer.dialog.DialogParams
 import com.rosan.installer.ui.page.installer.dialog.DialogParamsType
 import com.rosan.installer.ui.page.installer.dialog.DialogViewAction
 import com.rosan.installer.ui.page.installer.dialog.DialogViewModel
+import com.rosan.installer.util.asUserReadableSplitName
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -382,7 +383,11 @@ private fun SingleItemCard(
                     }
 
                     is AppEntity.SplitEntity -> {
-                        Text(app.splitName, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                        Text(
+                            app.splitName.asUserReadableSplitName(),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold
+                        )
                         Text(
                             text = stringResource(R.string.installer_file_name, app.name),
                             style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/com/rosan/installer/ui/page/settings/preferred/PreferredPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/settings/preferred/PreferredPage.kt
@@ -197,19 +197,6 @@ fun PreferredPage(
                                     PreferredViewAction.ChangeShowDialogInstallExtendedMenu(it)
                                 )
                             })
-                        /* SwitchWidget(
-                             icon = AppIcons.NotificationDisabled,
-                             title = stringResource(id = R.string.disable_notification),
-                             description = stringResource(id = R.string.close_immediately_on_dialog_dismiss),
-                             checked = viewModel.state.disableNotificationForDialogInstall,
-                             onCheckedChange = {
-                                 viewModel.dispatch(
-                                     PreferredViewAction.ChangeShowDisableNotificationForDialogInstall(
-                                         it
-                                     )
-                                 )
-                             }
-                         )*/
                     }
                 }
             }

--- a/app/src/main/java/com/rosan/installer/util/SplitNameUtil.kt
+++ b/app/src/main/java/com/rosan/installer/util/SplitNameUtil.kt
@@ -1,0 +1,112 @@
+package com.rosan.installer.util
+
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.rosan.installer.R
+import java.util.Locale
+
+private const val SPLIT_CONFIG_PREFIX = "split_config."
+private const val CONFIG_PREFIX = "config."
+
+/**
+ * [公开API - Composable]
+ *
+ * 将原始的 splitName 转换为用户可读的格式。
+ * 例如 "split_config.zh" -> "语言: 中文"
+ * "split_config.armeabi-v7a" -> "架构: ARMv7a (32-bit)"
+ *
+ * @author wxxsfxyzm
+ * @return 返回一个在 Composable 中使用的本地化字符串。
+ */
+@Composable
+fun String.asUserReadableSplitName(): String {
+    // 移除通用的前缀，提取核心名称，如 "zh", "armeabi-v7a"
+    val coreName = this.removePrefix(SPLIT_CONFIG_PREFIX).removePrefix(CONFIG_PREFIX)
+
+    // --- 尝试解析为语言 ---
+    val languageDisplayName = getLanguageDisplayName(coreName)
+    if (languageDisplayName != null) {
+        return stringResource(R.string.split_name_language, languageDisplayName)
+    }
+
+    // --- 尝试解析为CPU架构 (ABI) ---
+    val abiDisplayName = getAbiDisplayName(coreName)
+    if (abiDisplayName != null) {
+        return stringResource(R.string.split_name_architecture, abiDisplayName)
+    }
+
+    // --- 尝试解析为屏幕密度 (DPI) ---
+    val dpiResId = getDpiStringResourceId(coreName)
+    if (dpiResId != null) {
+        // 使用格式化字符串，将本地化的DPI描述填入
+        return stringResource(R.string.split_name_density, stringResource(dpiResId))
+    }
+    // 特别处理 "480dpi" 这种数字格式，它们本身具有可读性
+    if (coreName.endsWith("dpi") && coreName.removeSuffix("dpi").all { it.isDigit() }) {
+        return stringResource(R.string.split_name_density, coreName)
+    }
+
+    // 如果无法识别，则返回原始的 splitName
+    return this
+}
+
+/**
+ * 根据语言代码，使用 Java 的 Locale 获取其显示名称
+ *
+ * @param code 语言代码，例如 "zh", "en"
+ * @return 本地化的语言名称，如果无法识别则返回 null
+ */
+private fun getLanguageDisplayName(code: String): String? {
+    val locale = Locale.forLanguageTag(code)
+    // 确保这是一个有效的语言代码，并且能生成一个不同于代码本身的显示名称
+    return if (locale.language.isNotEmpty() && locale.displayLanguage.lowercase() != code.lowercase()) {
+        // 返回在当前设备语言环境下的语言名称 (例如，系统为中文时返回"英语"，系统为英文时返回"English")
+        locale.getDisplayName(Locale.getDefault())
+    } else {
+        null
+    }
+}
+
+/**
+ * 识别常见的 ABI 名称并返回更具描述性的版本
+ *
+ * @param name ABI 名称
+ * @return 描述性的 ABI 名称，如果无法识别则返回 null
+ */
+private fun getAbiDisplayName(name: String): String? {
+    return when (name) {
+        "armeabi" -> "ARM (32-bit)"
+        "armeabi-v7a" -> "ARMv7a (32-bit)"
+        "armeabi_v7a" -> "ARMv7a (32-bit)"
+        "arm64-v8a" -> "ARMv8a (64-bit)"
+        "arm64_v8a" -> "ARMv8a (64-bit)"
+        "x86" -> "x86 (32-bit)"
+        "x86_64" -> "x86 (64-bit)"
+        "mips" -> "MIPS"
+        "mips64" -> "MIPS64"
+        else -> null
+    }
+}
+
+/**
+ * 识别常见的屏幕密度(DPI)名称并返回更具描述性的版本。
+ *
+ * @param name DPI 名称
+ * @return 描述性的 DPI 名称，如果无法识别则返回 null。
+ */
+@StringRes
+private fun getDpiStringResourceId(name: String): Int? {
+    return when (name) {
+        "ldpi" -> R.string.split_dpi_ldpi
+        "mdpi" -> R.string.split_dpi_mdpi
+        "hdpi" -> R.string.split_dpi_hdpi
+        "xhdpi" -> R.string.split_dpi_xhdpi
+        "xxhdpi" -> R.string.split_dpi_xxhdpi
+        "xxxhdpi" -> R.string.split_dpi_xxxhdpi
+        "tvdpi" -> R.string.split_dpi_tvdpi
+        "nodpi" -> R.string.split_dpi_nodpi
+        "anydpi" -> R.string.split_dpi_anydpi
+        else -> null
+    }
+}

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -243,15 +243,93 @@
     <string name="downgrade_version_prefix">Downgrade</string>
     <string name="install_choice">Seleccionar PKG</string>
 
-    <string name="show_dialog_install_extended_menu">Mostrar menú extendido</string>
+    <string name="show_dialog_when_pressing_notification">Mostrar diálogo al presionar la notificación</string>
+    <string name="change_notification_touch_behavior">Cambiar comportamiento táctil de la notificación</string>
+    <string name="show_dialog_install_extended_menu">Mostrar menú extendido (Experimental)</string>
     <string name="show_dialog_install_extended_menu_desc">Mostrar más opciones en el diálogo de instalación</string>
+    <string name="extended_menu">Menú Extendido</string>
+    <string name="disable_notification">Deshabilitar Notificación</string>
+    <string name="close_immediately_on_dialog_dismiss">Cerrar Inmediatamente al Descartar Diálogo</string>
     <string name="set_countdown">Establecer cuenta regresiva</string>
-    <string name="dhizuku_auto_close_countdown_desc">Cuenta regresiva para cerrar automáticamente después de una instalación exitosa con Dhizuku</string>
-    <string name="grant_permission_after_install">Haz clic para otorgar permiso después de la instalación</string>
-    <string name="config_allow_test">Permitir depuración</string>
-    <string name="config_allow_test_desc">Permitir aplicaciones marcadas para depuración</string>
-    <string name="config_all_users">Instalar para todos los usuarios</string>
-    <string name="config_allow_downgrade">Permitir downgrade</string>
-    <string name="config_allow_downgrade_desc">Permitir que las aplicaciones se degraden (puede no funcionar en todas las ROMs)</string>
+    <string name="dhizuku_auto_close_countdown_desc">Cuenta regresiva para el cierre automático después de que la instalación de Dhizuku se complete</string>
+    <string name="dhizuku_cannot_set_installer_desc">¡El modo Dhizuku no admite la configuración del instalador!</string>
+    <string name="grant_permission_after_install">Tocar para otorgar permiso después de la instalación</string>
+    <string name="permission_list">Lista de Permisos</string>
+    <string name="permission_list_desc">Lista de permisos solicitados por el paquete que se está instalando</string>
+
+    <!--  InstallOptions Start  -->
+    <string name="config_allow_test">Permitir Pruebas</string>
+    <string name="config_allow_test_desc">Si el paquete que se está instalando es una aplicación solo de prueba, permitir su instalación.</string>
+    <string name="internal">Almacenamiento Interno</string>
+    <string name="internal_desc">Forzar la instalación del paquete en el almacenamiento interno.</string>
+    <string name="external">Almacenamiento Externo</string>
+    <string name="external_desc">Forzar la instalación del paquete en el almacenamiento externo.</string>
+    <string name="from_adb">Solicitud de instalación desde ADB</string>
+    <string name="from_adb_desc">Indica al sistema que la solicitud de instalación fue realizada por ADB</string>
+    <string name="config_all_users">Instalar para Todos los Usuarios</string>
+    <string name="config_all_users_desc">Instala el paquete para todos los usuarios del sistema, en lugar de solo el usuario especificado o predeterminado</string>
+    <string name="config_allow_downgrade">Permitir Reversión</string>
+    <string name="config_allow_downgrade_desc">Intenta revertir la versión actualmente instalada del paquete a la que se está instalando (puede que no funcione en todas las ROMs)</string>
+    <string name="config_grant_all_permissions">Otorgar Todos los Permisos Solicitados</string>
+    <string name="config_grant_all_permissions_desc">Otorga automáticamente todos los permisos que solicita el paquete. Tenga en cuenta que esto solo se aplica a los permisos de tiempo de ejecución. Permisos especiales como Acceso a Todos los Archivos o Accesibilidad no se otorgarán automáticamente.</string>
+    <string name="force_volume_uuid">Forzar UUID de Volumen</string>
+    <string name="force_volume_uuid_desc">Permite especificar un UUID de volumen para instalar el paquete.</string>
+    <string name="force_permission_prompt">Forzar Solicitud de Permiso</string>
+    <string name="force_permission_prompt_desc">Fuerza a que incluso los instaladores del sistema muestren el mensaje de confirmación de instalación.</string>
+    <string name="instant_app">Aplicación Instantánea</string>
+    <string name="instant_app_desc">Instala el paquete como una aplicación instantánea.</string>
+    <string name="dont_kill_app">No Matar Aplicación</string>
+    <string name="dont_kill_app_desc">Se usa al instalar una función para una aplicación dividida para evitar que la aplicación principal se cierre durante la instalación.</string>
+    <string name="full_app">Aplicación Completa</string>
+    <string name="full_app_desc">Indica que el paquete que se está instalando es una aplicación completa. Se puede usar para actualizar aplicaciones instantáneas a aplicaciones completas.</string>
+    <string name="allocate_aggressive">Asignar Agresivamente</string>
+    <string name="allocate_aggressive_desc">Indica que el paquete es "crítico para la salud o seguridad del sistema" y eliminará más agresivamente los archivos borrables para hacer espacio si es necesario.</string>
+    <string name="virtual_preload">Precarga Virtual</string>
+    <string name="virtual_preload_desc">Indica que el paquete es una precarga virtual.</string>
+    <string name="apex" translatable="false">APEX</string>
+    <string name="apex_desc">Indica que el paquete que se está instalando es un paquete APEX</string>
+    <string name="enable_rollback">Habilitar Reversión</string>
+    <string name="enable_rollback_desc">Permitir futuras reversiones de este paquete.</string>
+    <string name="disable_verification">Deshabilitar Verificación</string>
+    <string name="disable_verification_desc">Deshabilita la verificación del paquete durante la instalación. Esto no es verificación de firma.</string>
+    <string name="staged">Escenificado</string>
+    <string name="staged_desc">Indica que este paquete se está instalando como parte de una instalación escenificada.</string>
+    <string name="config_all_whitelist_restricted_permissions">Permitir Permisos Restringidos</string>
+    <string name="config_all_whitelist_restricted_permissions_desc">Permitir que se otorguen permisos restringidos para el paquete que se está instalando.</string>
+    <string name="disable_allowed_apex_update_check">Deshabilitar Verificación de Actualización de APEX Permitida</string>
+    <string name="disable_allowed_apex_update_check_desc">No verificar si el APEX instalado se puede actualizar.</string>
+    <string name="config_bypass_low_target_sdk">Omitir Bloqueo de SDK de Destino Bajo</string>
+    <string name="config_bypass_low_target_sdk_desc">Permite instalar aplicaciones dirigidas a versiones de SDK antiguas.</string>
+    <string name="dry_run">Prueba en Seco</string>
+    <string name="dry_run_desc">Verificar el paquete, pero no instalarlo.</string>
+
+    <string name="replace_existing">Reemplazar Existente</string>
+    <string name="replace_existing_desc">Si el paquete que se va a instalar ya existe, reemplazarlo/actualizarlo.</string>
+    <!--  InstallOptions End  -->
+
+    <!-- MultiApkZip Installer -->
+    <string name="installer_file_name">Archivo: %1$s</string>
+    <string name="installer_select_from_zip">Seleccionar de archivo zip</string>
+    <string name="installer_multi_apk_zip_description">Este archivo contiene varias aplicaciones separadas, seleccione las aplicaciones que desea procesar.</string>
+    <string name="installing_progress_text">Instalando %1$s (%2$d/%3$d)</string>
+    <string name="installer_completed">Instalación completa</string>
+    <string name="installer_completed_subtitle">Exitoso: %1$s, fallido: %2$s</string>
+    <string name="installer_current_install_mode_not_supported">El modo actual no admite la instalación de este tipo de archivo</string>
+    <!-- MultiApkZip End -->
+
+    <!-- SplitNameUtil Start -->
+    <string name="split_name_language">División de idioma: %1$s</string>
+    <string name="split_name_architecture">División de arquitectura: %1$s</string>
+    <string name="split_name_density">Densidad de pantalla: %1$s</string>
+    <string name="split_dpi_ldpi">Baja (~120dpi)</string>
+    <string name="split_dpi_mdpi">Media (~160dpi)</string>
+    <string name="split_dpi_hdpi">Alta (~240dpi)</string>
+    <string name="split_dpi_xhdpi">Extra Alta (~320dpi)</string>
+    <string name="split_dpi_xxhdpi">Extra Extra Alta (~480dpi)</string>
+    <string name="split_dpi_xxxhdpi">Extra Extra Extra Alta (~640dpi)</string>
+    <string name="split_dpi_tvdpi">TV (~213dpi)</string>
+    <string name="split_dpi_nodpi">Sin escalado</string>
+    <string name="split_dpi_anydpi">Cualquier densidad</string>
+    <!-- SplitNameUtil End -->
 
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -315,4 +315,19 @@
     <string name="installer_completed_subtitle">成功 %1$s 个，失败 %2$s 个</string>
     <string name="installer_current_install_mode_not_supported">当前模式不支持安装该类型的文件</string>
     <!-- MultiApkZip End -->
+
+    <!-- SplitNameUtil Start -->
+    <string name="split_name_language">语言分包: %1$s</string>
+    <string name="split_name_architecture">架构分包: %1$s</string>
+    <string name="split_name_density">屏幕密度: %1$s</string>
+    <string name="split_dpi_ldpi">低 (~120dpi)</string>
+    <string name="split_dpi_mdpi">中 (~160dpi)</string>
+    <string name="split_dpi_hdpi">高 (~240dpi)</string>
+    <string name="split_dpi_xhdpi">超高 (~320dpi)</string>
+    <string name="split_dpi_xxhdpi">超超高 (~480dpi)</string>
+    <string name="split_dpi_xxxhdpi">超超超高 (~640dpi)</string>
+    <string name="split_dpi_tvdpi">电视 (~213dpi)</string>
+    <string name="split_dpi_nodpi">不缩放</string>
+    <string name="split_dpi_anydpi">任意密度</string>
+    <!-- SplitNameUtil End -->
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -314,4 +314,19 @@
     <string name="installer_completed_subtitle">成功 %1$s 個，失敗 %2$s 個</string>
     <string name="installer_current_install_mode_not_supported">目前模式不支援安裝此類型檔案</string>
     <!-- MultiApkZip End -->
+
+    <!-- SplitNameUtil Start -->
+    <string name="split_name_language">語言分包: %1$s</string>
+    <string name="split_name_architecture">架構分包: %1$s</string>
+    <string name="split_name_density">螢幕密度: %1$s</string>
+    <string name="split_dpi_ldpi">低 (~120dpi)</string>
+    <string name="split_dpi_mdpi">中 (~160dpi)</string>
+    <string name="split_dpi_hdpi">高 (~240dpi)</string>
+    <string name="split_dpi_xhdpi">超高 (~320dpi)</string>
+    <string name="split_dpi_xxhdpi">超超高 (~480dpi)</string>
+    <string name="split_dpi_xxxhdpi">超超超高 (~640dpi)</string>
+    <string name="split_dpi_tvdpi">電視 (~213dpi)</string>
+    <string name="split_dpi_nodpi">不縮放</string>
+    <string name="split_dpi_anydpi">任意密度</string>
+    <!-- SplitNameUtil End -->
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -321,4 +321,19 @@
     <string name="installer_completed_subtitle">Successful %1$s, failed %2$s</string>
     <string name="installer_current_install_mode_not_supported">Current mode does not support installing this type of file</string>
     <!-- MultiApkZip End -->
+
+    <!-- SplitNameUtil Start -->
+    <string name="split_name_language">Language split: %1$s</string>
+    <string name="split_name_architecture">Architecture split: %1$s</string>
+    <string name="split_name_density">Screen density: %1$s</string>
+    <string name="split_dpi_ldpi">Low (~120dpi)</string>
+    <string name="split_dpi_mdpi">Medium (~160dpi)</string>
+    <string name="split_dpi_hdpi">High (~240dpi)</string>
+    <string name="split_dpi_xhdpi">Extra High (~320dpi)</string>
+    <string name="split_dpi_xxhdpi">Extra Extra High (~480dpi)</string>
+    <string name="split_dpi_xxxhdpi">Extra Extra Extra High (~640dpi)</string>
+    <string name="split_dpi_tvdpi">TV (~213dpi)</string>
+    <string name="split_dpi_nodpi">No scaling</string>
+    <string name="split_dpi_anydpi">Any density</string>
+    <!-- SplitNameUtil End -->
 </resources>


### PR DESCRIPTION
This commit introduces a utility to display split APK names in a more user-friendly format. It also includes new string resources for this feature and updates translations.

- Added `SplitNameUtil.kt` to convert raw split names (e.g., "split_config.zh") into human-readable strings (e.g., "语言: 中文").
- Updated `InstallChoiceDialog.kt` to use the new utility for displaying split APK names.
- Added new string resources for split name components (language, architecture, density) and their localized versions.
- Updated Spanish, Simplified Chinese, and Traditional Chinese translations.