### PR TITLE
fix: initialize config name correctly for new and existing config

### DIFF
--- a/app/src/main/java/com/rosan/installer/ui/page/settings/config/edit/EditViewModel.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/settings/config/edit/EditViewModel.kt
@@ -234,8 +234,17 @@ class EditViewModel(
     private fun loadData() {
         loadDataJob?.cancel()
         loadDataJob = viewModelScope.launch(Dispatchers.IO) {
+            // Check if it is a new configuration or an existing one.
+            val configEntity = if (id == null) {
+                // If new, use default config but with an empty name.
+                ConfigEntity.default.copy(name = "")
+            } else {
+                // If editing, find the config by id. Fallback to a default empty one if not found.
+                repo.find(id) ?: ConfigEntity.default.copy(name = "")
+            }
+
             state = state.copy(
-                data = EditViewState.Data.build(id?.let { repo.find(id) } ?: ConfigEntity.default)
+                data = EditViewState.Data.build(configEntity)
             )
             globalAuthorizer = getGlobalAuthorizer()
             globalInstallMode = getGlobalInstallMode()

--- a/app/src/main/java/com/rosan/installer/ui/page/settings/config/edit/EditViewState.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/settings/config/edit/EditViewState.kt
@@ -49,7 +49,7 @@ data class EditViewState(
 
         companion object {
             fun build(config: ConfigEntity): Data = Data(
-                name = "",
+                name = config.name,
                 description = config.description,
                 authorizer = config.authorizer,
                 customizeAuthorizer = config.customizeAuthorizer,


### PR DESCRIPTION
When creating a new configuration, the name field will now be initialized as an empty string.
When editing an existing configuration, the name field will be correctly populated from the stored configuration. If the configuration is not found, it defaults to an empty string.