### PR TITLE
feat(multiapk): support install multiple apk by sharing them to installerx

### DIFF
--- a/app/src/main/java/com/rosan/installer/data/app/model/entity/AnalyseExtraEntity.kt
+++ b/app/src/main/java/com/rosan/installer/data/app/model/entity/AnalyseExtraEntity.kt
@@ -1,7 +1,5 @@
 package com.rosan.installer.data.app.model.entity
 
-import com.rosan.installer.data.app.util.DataType
-
 /**
  * 包含了分析过程中可能需要的附加信息。
  * @param cacheDirectory 用于存放临时文件的缓存目录路径。

--- a/app/src/main/java/com/rosan/installer/data/app/model/entity/AppEntity.kt
+++ b/app/src/main/java/com/rosan/installer/data/app/model/entity/AppEntity.kt
@@ -2,7 +2,6 @@ package com.rosan.installer.data.app.model.entity
 
 import android.graphics.drawable.Drawable
 import com.rosan.installer.build.Architecture
-import com.rosan.installer.data.app.util.DataType
 
 sealed class AppEntity {
     abstract val packageName: String

--- a/app/src/main/java/com/rosan/installer/data/app/model/entity/DataType.kt
+++ b/app/src/main/java/com/rosan/installer/data/app/model/entity/DataType.kt
@@ -1,7 +1,6 @@
-package com.rosan.installer.data.app.util
+package com.rosan.installer.data.app.model.entity
 
 import kotlinx.serialization.Serializable
-
 
 @Serializable
 enum class DataType {
@@ -9,6 +8,8 @@ enum class DataType {
     APKS,
     APKM,
     XAPK,
+    MULTI_APK,
     MULTI_APK_ZIP,
-    MODULE_ZIP
+    MODULE_ZIP,
+    NONE
 }

--- a/app/src/main/java/com/rosan/installer/data/app/model/entity/InstallEntity.kt
+++ b/app/src/main/java/com/rosan/installer/data/app/model/entity/InstallEntity.kt
@@ -1,7 +1,5 @@
 package com.rosan.installer.data.app.model.entity
 
-import com.rosan.installer.data.app.util.DataType
-
 data class InstallEntity(
     val name: String,
     val packageName: String,

--- a/app/src/main/java/com/rosan/installer/data/app/model/impl/installer/IBinderInstallerRepoImpl.kt
+++ b/app/src/main/java/com/rosan/installer/data/app/model/impl/installer/IBinderInstallerRepoImpl.kt
@@ -17,10 +17,10 @@ import android.os.IInterface
 import android.os.ServiceManager
 import com.rosan.dhizuku.api.Dhizuku
 import com.rosan.installer.BuildConfig
+import com.rosan.installer.data.app.model.entity.DataType
 import com.rosan.installer.data.app.model.entity.InstallEntity
 import com.rosan.installer.data.app.model.entity.InstallExtraInfoEntity
 import com.rosan.installer.data.app.repo.InstallerRepo
-import com.rosan.installer.data.app.util.DataType
 import com.rosan.installer.data.app.util.InstallOption
 import com.rosan.installer.data.app.util.PackageInstallerUtil.Companion.installFlags
 import com.rosan.installer.data.app.util.PackageManagerUtil

--- a/app/src/main/java/com/rosan/installer/data/app/util/AppEntityInfo.kt
+++ b/app/src/main/java/com/rosan/installer/data/app/util/AppEntityInfo.kt
@@ -18,6 +18,7 @@ fun AppEntity.getInfo(context: Context): AppEntityInfo = when (this) {
         icon = this.icon ?: ContextCompat.getDrawable(context, android.R.drawable.sym_def_app_icon),
         title = this.label ?: this.packageName
     )
+
     else -> {
         val packageManager = context.packageManager
         var applicationInfo: ApplicationInfo? = null
@@ -54,3 +55,23 @@ fun List<AppEntity>.sortedBest(): List<AppEntity> = this.sortedWith(
 
 fun List<AppEntity>.getInfo(context: Context): AppEntityInfo =
     this.sortedBest().first().getInfo(context)
+
+/**
+ * Reusable extension function to deduplicate a list of AppEntity.
+ * It uses a composite key to uniquely identify an app version.
+ */
+// TODO cpu abi
+fun List<AppEntity>.deduplicate(): List<AppEntity> {
+    return this.distinctBy { app ->
+        when (app) {
+            // For BaseEntity, the unique key is a combination of these three properties.
+            is AppEntity.BaseEntity -> Triple(app.packageName, app.versionCode, app.versionName)
+            // For other types, their specific properties (like split name) are part of the name.
+            // Temporarily not needed, but can be added if necessary.
+            // is AppEntity.SplitEntity -> Pair(app.packageName, app.name)
+            // is AppEntity.DexMetadataEntity -> Pair(app.packageName, app.name)
+            // Use object identity as a fallback for any other types.
+            else -> app
+        }
+    }
+}

--- a/app/src/main/java/com/rosan/installer/data/installer/model/entity/SelectInstallEntity.kt
+++ b/app/src/main/java/com/rosan/installer/data/installer/model/entity/SelectInstallEntity.kt
@@ -5,4 +5,50 @@ import com.rosan.installer.data.app.model.entity.AppEntity
 data class SelectInstallEntity(
     val app: AppEntity,
     val selected: Boolean
-)
+) {
+    companion object {
+        /**
+         * Finds and returns the single "latest" entity from a list of items in the same group.
+         * The latest version is determined by the highest versionCode, with versionName as a tie-breaker.
+         * This function contains the core sorting logic.
+         *
+         * @param items The list of SelectInstallEntity to process.
+         * @return The single latest SelectInstallEntity, or null if the list is empty.
+         */
+        fun getLatestInGroup(items: List<SelectInstallEntity>): SelectInstallEntity? {
+            // If the list is empty, there is no latest item.
+            if (items.isEmpty()) {
+                return null
+            }
+            // If there's only one, it's intrinsically the "latest".
+            if (items.size == 1) {
+                return items.first()
+            }
+
+            // Find the latest item by sorting and return it.
+            return items.sortedWith(
+                compareByDescending<SelectInstallEntity> {
+                    (it.app as? AppEntity.BaseEntity)?.versionCode ?: 0L
+                }.thenByDescending {
+                    (it.app as? AppEntity.BaseEntity)?.versionName ?: ""
+                }
+            ).first() // The first one after sorting is the latest.
+        }
+
+        /**
+         * Takes a list of entities from the same group and returns a new list
+         * with only the "latest" version selected, as determined by getLatestInGroup().
+         *
+         * @param items The list of SelectInstallEntity to process.
+         * @return A new list with the correct item selected.
+         */
+        fun selectLatestInGroup(items: List<SelectInstallEntity>): List<SelectInstallEntity> {
+            // REUSE the core logic to find the single latest item.
+            val latestItem = getLatestInGroup(items)
+
+            // Return a new list where only the latest item is selected.
+            // If latestItem is null (meaning the input list was empty), this correctly produces an empty list.
+            return items.map { it.copy(selected = it == latestItem) }
+        }
+    }
+}

--- a/app/src/main/java/com/rosan/installer/data/installer/model/impl/installer/ActionHandler.kt
+++ b/app/src/main/java/com/rosan/installer/data/installer/model/impl/installer/ActionHandler.kt
@@ -13,10 +13,10 @@ import com.rosan.installer.R
 import com.rosan.installer.data.app.model.entity.AnalyseExtraEntity
 import com.rosan.installer.data.app.model.entity.AppEntity
 import com.rosan.installer.data.app.model.entity.DataEntity
+import com.rosan.installer.data.app.model.entity.DataType
 import com.rosan.installer.data.app.model.entity.InstallEntity
 import com.rosan.installer.data.app.model.entity.InstallExtraInfoEntity
 import com.rosan.installer.data.app.model.impl.AnalyserRepoImpl
-import com.rosan.installer.data.app.util.DataType
 import com.rosan.installer.data.installer.model.entity.ProgressEntity
 import com.rosan.installer.data.installer.model.entity.SelectInstallEntity
 import com.rosan.installer.data.installer.model.exception.ResolveException
@@ -132,12 +132,15 @@ class ActionHandler(scope: CoroutineScope, installer: InstallerRepo) :
                 installer.config.installMode == ConfigEntity.InstallMode.AutoNotification
 
         val isMultiApkZip = installer.entities.firstOrNull()?.app?.containerType == DataType.MULTI_APK_ZIP
-
-        Timber
-            .d("[id=${installer.id}] analyse: Analyse completed. isNotificationInstall=$isNotificationInstall, isMultiApkZip=$isMultiApkZip")
+        val isMultiApk = installer.entities.firstOrNull()?.app?.containerType == DataType.MULTI_APK
+        Timber.d("[id=${installer.id}] analyse: Analyse completed. isNotificationInstall=$isNotificationInstall, isMultiApkZip=$isMultiApkZip")
         if (isNotificationInstall && isMultiApkZip) {
-            Timber
-                .w("[id=${installer.id}] analyse: Multi-APK ZIP not supported in notification mode. Emitting AnalysedUnsupported.")
+            Timber.w("[id=${installer.id}] analyse: Multi-APK ZIP not supported in notification mode. Emitting AnalysedUnsupported.")
+            installer.progress.emit(
+                ProgressEntity.AnalysedUnsupported(context.getString(R.string.installer_current_install_mode_not_supported))
+            )
+        } else if (isNotificationInstall && isMultiApk) {
+            Timber.w("[id=${installer.id}] analyse: Multi-APK not supported in notification mode. Emitting AnalysedUnsupported.")
             installer.progress.emit(
                 ProgressEntity.AnalysedUnsupported(context.getString(R.string.installer_current_install_mode_not_supported))
             )

--- a/app/src/main/java/com/rosan/installer/ui/page/installer/dialog/inner/InstallCompleteDialog.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/installer/dialog/inner/InstallCompleteDialog.kt
@@ -71,7 +71,10 @@ fun installCompletedDialog(
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
             ) {
                 item { Spacer(modifier = Modifier.size(1.dp)) }
-                items(results, key = { it.entity.app.name }) { result ->
+                items(results, key = { result ->
+                    val app = result.entity.app as AppEntity.BaseEntity
+                    app.packageName + app.name
+                }) { result ->
                     ResultItemCard(result)
                 }
                 item { Spacer(modifier = Modifier.size(1.dp)) }

--- a/app/src/main/java/com/rosan/installer/ui/page/installer/dialog/inner/InstallPrepareDialog.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/installer/dialog/inner/InstallPrepareDialog.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.rosan.installer.R
 import com.rosan.installer.data.app.model.entity.AppEntity
-import com.rosan.installer.data.app.util.DataType
+import com.rosan.installer.data.app.model.entity.DataType
 import com.rosan.installer.data.app.util.sortedBest
 import com.rosan.installer.data.installer.repo.InstallerRepo
 import com.rosan.installer.ui.icons.AppIcons

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -314,7 +314,8 @@
     <!-- MultiApkZip Installer -->
     <string name="installer_file_name">文件: %1$s</string>
     <string name="installer_select_from_zip">从压缩包中选择</string>
-    <string name="installer_multi_apk_zip_description">该文件包含多个独立的应用程序，请选择您想要处理的应用。</string>
+    <string name="installer_multi_apk_zip_description">该文件包含多个应用程序，请选择想要安装的应用</string>
+    <string name="installer_multi_apk_description">请选择要安装的应用</string>
     <string name="installing_progress_text">正在安装 %1$s (%2$d/%3$d)</string>
     <string name="installer_completed">安装完成</string>
     <string name="installer_completed_subtitle">成功 %1$s 个，失败 %2$s 个</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -313,7 +313,8 @@
     <!-- MultiApkZip Installer -->
     <string name="installer_file_name">檔案: %1$s</string>
     <string name="installer_select_from_zip">從壓縮檔中選擇</string>
-    <string name="installer_multi_apk_zip_description">此檔案包含多個獨立應用程式，請選擇您想要處理的應用程式。</string>
+    <string name="installer_multi_apk_zip_description">此檔案包含多個獨立應用程式，請選擇想要處理的應用程式</string>
+    <string name="installer_multi_apk_description">請選擇要安裝的應用程式</string>
     <string name="installing_progress_text">正在安裝 %1$s (%2$d/%3$d)</string>
     <string name="installer_completed">安裝完成</string>
     <string name="installer_completed_subtitle">成功 %1$s 個，失敗 %2$s 個</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -320,7 +320,8 @@
     <!-- MultiApkZip Installer -->
     <string name="installer_file_name">File: %1$s</string>
     <string name="installer_select_from_zip">Select from zip file</string>
-    <string name="installer_multi_apk_zip_description">This file contains multiple separate applications, please select the applications you want to process.</string>
+    <string name="installer_multi_apk_zip_description">This file contains multiple separate applications, please select the applications you want to install</string>
+    <string name="installer_multi_apk_description">Please select the applications you want to install</string>
     <string name="installing_progress_text">Installing %1$s (%2$d/%3$d)</string>
     <string name="installer_completed">Install complete</string>
     <string name="installer_completed_subtitle">Successful %1$s, failed %2$s</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@
 # https://mvnrepository.com/
 
 [versions]
-agp = "8.11.1"
+agp = "8.12.0"
 commonsCompress = "1.27.1"
 kotlin = "2.2.0"
 ksp = "2.2.0-2.0.2"


### PR DESCRIPTION
This commit supports install multiple apk by multi-select apk(s) and sharing them to installerx
InstallerX will handle the case whether input has same package or select the newest version.

Changes for both MULTI_APK and MULTI_APK_ZIP: when user selected to cancel an app in radioGroup, the card will automatically collapse and when user expand it, the radioGroup will re-select one that is most suitable.

Introduce a deduplicate method for entityToInstall list, but not enabled since abi analyse is not present for the moment.

Bump AGP to 8.12

