### PR TITLE
fix: fix installation issues

### DIFF
--- a/app/src/main/java/com/rosan/installer/data/settings/model/room/entity/ConfigEntity.kt
+++ b/app/src/main/java/com/rosan/installer/data/settings/model/room/entity/ConfigEntity.kt
@@ -61,7 +61,7 @@ data class ConfigEntity(
             description = "",
             authorizer = Authorizer.Global,
             customizeAuthorizer = "",
-            installMode = InstallMode.Dialog,
+            installMode = InstallMode.Global,
             installer = "com.miui.packageinstaller",
             enableManualDexopt = false,
             forceDexopt = false,

--- a/app/src/main/java/com/rosan/installer/ui/activity/InstallerActivity.kt
+++ b/app/src/main/java/com/rosan/installer/ui/activity/InstallerActivity.kt
@@ -74,7 +74,16 @@ class InstallerActivity : ComponentActivity(), KoinComponent {
         super.onCreate(savedInstanceState)
         Timber.d("onCreate. SavedInstanceState is ${if (savedInstanceState == null) "null" else "not null"}")
         restoreInstaller(savedInstanceState)
-        checkPermissionsAndStartProcess()
+        val installerId =
+            if (savedInstanceState == null) intent?.getStringExtra(KEY_ID) else savedInstanceState.getString(KEY_ID)
+
+        if (installerId == null) {
+            Timber.d("onCreate: This is a fresh launch for a new task. Starting permission and resolve process.")
+            // Only start the process for a completely new task.
+            checkPermissionsAndStartProcess()
+        } else {
+            Timber.d("onCreate: Re-attaching to existing installer ($installerId). Skipping resolve process.")
+        }
         showContent()
     }
 


### PR DESCRIPTION
This commit changes the default install mode from "Dialog" to "Global" in the `ConfigEntity.kt` file.

Additionally, it modifies the `InstallerActivity.kt` to prevent re-resolving the installer when the activity is re-created, for example, due to a configuration change. The installer resolution process will now only occur if it's a fresh launch for a new installation task. Closes #157 