### PR TITLE
fix(installer): improve SDK info display and animations

### DIFF
--- a/app/src/main/java/com/rosan/installer/ui/page/settings/config/edit/NewEditPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/settings/config/edit/NewEditPage.kt
@@ -176,7 +176,7 @@ fun NewEditPage(
                         onClick = { navController.navigateUp() },
                         icon = Icons.AutoMirrored.TwoTone.ArrowBack,
                         modifier = Modifier.size(36.dp),
-                        containerColor = MaterialTheme.colorScheme.surface
+                        containerColor = MaterialTheme.colorScheme.surfaceBright
                     )
                 },
                 scrollBehavior = scrollBehavior,

--- a/app/src/main/java/com/rosan/installer/ui/page/settings/preferred/subpage/installer/NewInstallerGlobalSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/settings/preferred/subpage/installer/NewInstallerGlobalSettingsPage.kt
@@ -64,7 +64,7 @@ fun NewInstallerGlobalSettingsPage(
                         onClick = { navController.navigateUp() },
                         icon = Icons.AutoMirrored.TwoTone.ArrowBack,
                         modifier = Modifier.size(36.dp),
-                        containerColor = MaterialTheme.colorScheme.surface
+                        containerColor = MaterialTheme.colorScheme.surfaceBright
                     )
                 },
                 scrollBehavior = scrollBehavior,

--- a/app/src/main/java/com/rosan/installer/ui/page/settings/preferred/subpage/theme/NewThemeSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/settings/preferred/subpage/theme/NewThemeSettingsPage.kt
@@ -52,7 +52,7 @@ fun NewThemeSettingsPage(
                         onClick = { navController.navigateUp() },
                         icon = Icons.AutoMirrored.TwoTone.ArrowBack,
                         modifier = Modifier.size(36.dp),
-                        containerColor = MaterialTheme.colorScheme.surface
+                        containerColor = MaterialTheme.colorScheme.surfaceBright
                     )
                 },
                 scrollBehavior = scrollBehavior,

--- a/app/src/main/java/com/rosan/installer/ui/widget/dialog/PositionDialog.kt
+++ b/app/src/main/java/com/rosan/installer/ui/widget/dialog/PositionDialog.kt
@@ -130,7 +130,7 @@ fun PositionDialog(
                         Column(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(bottom = animatedButtonHeight)
+                                .padding(bottom = animatedButtonHeight.coerceAtLeast(0.dp))
                                 .animateContentSize(
                                     animationSpec = spring(
                                         dampingRatio = Spring.DampingRatioMediumBouncy,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -263,9 +263,9 @@
     <string name="installer_package_name">Package: %1$s</string>
     <string name="installer_package_min_sdk_label" translatable="false">Min: </string>
     <string name="installer_package_target_sdk_label" translatable="false">Target: </string>
-    <string name="installer_package_sdk_value" translatable="false">%1$s (Android %2$s)</string>
-    <string name="installer_package_min_sdk_label_short" translatable="false">MinSDK: %1$s</string>
-    <string name="installer_package_target_sdk_label_short" translatable="false">TargetSDK: %1$s</string>
+    <string name="installer_package_sdk_value" translatable="false">%1$s(Android%2$s)</string>
+    <string name="installer_package_min_sdk_label_short" translatable="false">Min: %1$s</string>
+    <string name="installer_package_target_sdk_label_short" translatable="false">Target: %1$s</string>
     <string name="installer_file_path">Path: %1$s</string>
 
     <string name="exception_install_failed_unknown">Unknown error</string>


### PR DESCRIPTION
- Refine the display of SDK information in the installation dialog:
    - Separate SDK version and Android version name for better readability.
    - Use icons and distinct styling for current and new SDK versions.
    - Remove redundant string resources.
- Ensure the "Analysing" state in the installer has a minimum duration for smoother UI transitions.
- Update the background color of back buttons in various settings pages to `surfaceBright` for consistency.