### PR TITLE
feat(installer): implement signature verification and enhance install warnings

### DIFF
--- a/app/src/main/java/com/rosan/installer/build/RsConfig.kt
+++ b/app/src/main/java/com/rosan/installer/build/RsConfig.kt
@@ -4,6 +4,7 @@ import android.content.res.Resources
 import android.os.Build
 import android.text.TextUtils
 import com.rosan.installer.BuildConfig
+import com.rosan.installer.util.convertLegacyLanguageCode
 
 object RsConfig {
     val LEVEL: Level = getLevel()
@@ -124,7 +125,7 @@ object RsConfig {
                     // Get the base language code (e.g., "en" from "en-US") and add it directly.
                     // No conversion logic is applied.
                     val langCode = locale.toLanguageTag().substringBefore('-')
-                    languageSet.add(langCode.convertLanguageCode())
+                    languageSet.add(langCode.convertLegacyLanguageCode())
                 }
             }
 
@@ -133,25 +134,5 @@ object RsConfig {
             return languageSet.toList()
         }
 
-    /**
-     * Converts legacy ISO 639 language codes to their modern equivalents.
-     * This ensures compatibility with older and non-standard APK splits.
-     *
-     * Logic is from the PackageUtil.kt file in the PackageInstaller project.
-     * Under Apache License 2.0.
-     *
-     * @param code The language code to convert.
-     * @return The converted, modern language code.
-     *
-     * @see <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
-     * @see <a href="https://github.com/vvb2060/PackageInstaller/blob/master/app/src/main/java/io/github/vvb2060/packageinstaller/model/PackageUtil.kt">PackageUtil</a>
-     */
-    private fun String.convertLanguageCode(): String =
-        when (this) {
-            "tl" -> "fil" // Tagalog -> Filipino
-            "iw" -> "he"  // Old Hebrew -> Hebrew
-            "ji" -> "yi"  // Old Yiddish -> Yiddish
-            "in" -> "id"  // Old Indonesian -> Indonesian
-            else -> this
-        }
+
 }

--- a/app/src/main/java/com/rosan/installer/data/app/model/entity/AppEntity.kt
+++ b/app/src/main/java/com/rosan/installer/data/app/model/entity/AppEntity.kt
@@ -31,6 +31,7 @@ sealed class AppEntity {
         override val containerType: DataType? = null,
         // Get from AndroidManifest.xml
         val permissions: List<String>? = null,
+        val signatureHash: String? = null,
     ) : AppEntity()
 
     data class SplitEntity(

--- a/app/src/main/java/com/rosan/installer/data/app/model/entity/InstalledAppInfo.kt
+++ b/app/src/main/java/com/rosan/installer/data/app/model/entity/InstalledAppInfo.kt
@@ -1,10 +1,11 @@
-package com.rosan.installer.data.app.util
+package com.rosan.installer.data.app.model.entity
 
 import android.content.Context
-import android.content.pm.ApplicationInfo // Import ApplicationInfo
+import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.graphics.drawable.Drawable
 import android.os.Build
+import com.rosan.installer.data.app.util.SignatureUtils
 import com.rosan.installer.data.common.util.compatVersionCode
 import com.rosan.installer.data.common.util.isPackageArchivedCompat
 import org.koin.core.component.KoinComponent
@@ -19,12 +20,15 @@ data class InstalledAppInfo(
     val applicationInfo: ApplicationInfo?, // Add this field
     val minSdk: Int?,
     val targetSdk: Int?,
+    val signatureHash: String? = null,
+    val isSystemApp: Boolean = false,
     val isArchived: Boolean = false
 ) {
     companion object : KoinComponent {
         fun buildByPackageName(packageName: String): InstalledAppInfo? {
             val context: Context = get()
             val packageManager = context.packageManager
+            val signatureHash = SignatureUtils.getInstalledAppSignatureHash(context, packageName)
             return try {
                 val packageInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     packageManager.getPackageInfo(
@@ -50,6 +54,8 @@ data class InstalledAppInfo(
                     applicationInfo = applicationInfo,
                     minSdk = applicationInfo?.minSdkVersion,
                     targetSdk = applicationInfo?.targetSdkVersion,
+                    signatureHash = signatureHash,
+                    isSystemApp = ((applicationInfo?.flags ?: 0) and ApplicationInfo.FLAG_SYSTEM) != 0,
                     isArchived = packageManager.isPackageArchivedCompat(packageName)
                 )
             } catch (e: PackageManager.NameNotFoundException) {

--- a/app/src/main/java/com/rosan/installer/data/app/model/entity/PackageAnalysisResult.kt
+++ b/app/src/main/java/com/rosan/installer/data/app/model/entity/PackageAnalysisResult.kt
@@ -1,6 +1,5 @@
 package com.rosan.installer.data.app.model.entity
 
-import com.rosan.installer.data.app.util.InstalledAppInfo
 import com.rosan.installer.data.installer.model.entity.SelectInstallEntity
 
 /**
@@ -11,5 +10,6 @@ import com.rosan.installer.data.installer.model.entity.SelectInstallEntity
 data class PackageAnalysisResult(
     val packageName: String,
     val appEntities: List<SelectInstallEntity>,
-    val installedAppInfo: InstalledAppInfo?
+    val installedAppInfo: InstalledAppInfo?,
+    val signatureMatchStatus: SignatureMatchStatus
 )

--- a/app/src/main/java/com/rosan/installer/data/app/model/entity/SignatureMatchStatus.kt
+++ b/app/src/main/java/com/rosan/installer/data/app/model/entity/SignatureMatchStatus.kt
@@ -1,0 +1,19 @@
+package com.rosan.installer.data.app.model.entity
+
+/**
+ * Represents the result of comparing the signature of a new APK
+ * with an already installed version of the same app.
+ */
+enum class SignatureMatchStatus {
+    /** The package is not currently installed on the device. */
+    NOT_INSTALLED,
+
+    /** The signatures match. It's a safe update. */
+    MATCH,
+
+    /** The signatures do NOT match. This is a potential security risk. */
+    MISMATCH,
+
+    /** Could not determine the signature for either the APK or the installed app. */
+    UNKNOWN_ERROR
+}

--- a/app/src/main/java/com/rosan/installer/data/app/model/impl/installer/IBinderInstallerRepoImpl.kt
+++ b/app/src/main/java/com/rosan/installer/data/app/model/impl/installer/IBinderInstallerRepoImpl.kt
@@ -27,8 +27,8 @@ import com.rosan.installer.data.app.model.entity.InstallExtraInfoEntity
 import com.rosan.installer.data.app.model.exception.InstallFailedBlacklistedPackageException
 import com.rosan.installer.data.app.repo.InstallerRepo
 import com.rosan.installer.data.app.util.InstallOption
-import com.rosan.installer.data.app.util.PackageInstallerUtil.Companion.abiOverride
-import com.rosan.installer.data.app.util.PackageInstallerUtil.Companion.installFlags
+import com.rosan.installer.data.app.util.PackageInstallerUtil.abiOverride
+import com.rosan.installer.data.app.util.PackageInstallerUtil.installFlags
 import com.rosan.installer.data.app.util.PackageManagerUtil
 import com.rosan.installer.data.app.util.sourcePath
 import com.rosan.installer.data.common.util.isPackageArchivedCompat
@@ -233,7 +233,10 @@ abstract class IBinderInstallerRepoImpl : InstallerRepo, KoinComponent {
                     Timber.d("Package $packageName is not archived, using replace existing option.")
                     InstallOption.ReplaceExisting.value
                 }
-
+        // Disable Dhizuku not supported stuff
+        if (config.authorizer == ConfigEntity.Authorizer.Dhizuku)
+            params.installFlags = params.installFlags and InstallOption.GrantAllRequestedPermissions.value.inv()
+        
         val baseApkArch = entities.firstOrNull { it.name == "base.apk" }?.arch
         Timber.d("Current Arch to install: $baseApkArch")
 

--- a/app/src/main/java/com/rosan/installer/data/app/util/AppEntityInfo.kt
+++ b/app/src/main/java/com/rosan/installer/data/app/util/AppEntityInfo.kt
@@ -55,23 +55,3 @@ fun List<AppEntity>.sortedBest(): List<AppEntity> = this.sortedWith(
 
 fun List<AppEntity>.getInfo(context: Context): AppEntityInfo =
     this.sortedBest().first().getInfo(context)
-
-/**
- * Reusable extension function to deduplicate a list of AppEntity.
- * It uses a composite key to uniquely identify an app version.
- */
-// TODO cpu abi
-fun List<AppEntity>.deduplicate(): List<AppEntity> {
-    return this.distinctBy { app ->
-        when (app) {
-            // For BaseEntity, the unique key is a combination of these three properties.
-            is AppEntity.BaseEntity -> Triple(app.packageName, app.versionCode, app.versionName)
-            // For other types, their specific properties (like split name) are part of the name.
-            // Temporarily not needed, but can be added if necessary.
-            // is AppEntity.SplitEntity -> Pair(app.packageName, app.name)
-            // is AppEntity.DexMetadataEntity -> Pair(app.packageName, app.name)
-            // Use object identity as a fallback for any other types.
-            else -> app
-        }
-    }
-}

--- a/app/src/main/java/com/rosan/installer/data/app/util/PackageInstallerUtil.kt
+++ b/app/src/main/java/com/rosan/installer/data/app/util/PackageInstallerUtil.kt
@@ -5,34 +5,32 @@ import com.rosan.installer.data.reflect.repo.ReflectRepo
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 
-class PackageInstallerUtil {
-    companion object : KoinComponent {
-        const val EXTRA_LEGACY_STATUS = "android.content.pm.extra.LEGACY_STATUS"
+object PackageInstallerUtil : KoinComponent {
+    const val EXTRA_LEGACY_STATUS = "android.content.pm.extra.LEGACY_STATUS"
 
-        private val installFlagsField = get<ReflectRepo>().getDeclaredField(
-            PackageInstaller.SessionParams::class.java,
-            "installFlags"
-        )!!.also { field ->
-            field.isAccessible = true
-        }
-
-        var PackageInstaller.SessionParams.installFlags: Int
-            get() = installFlagsField.getInt(this)
-            set(value) {
-                installFlagsField.setInt(this, value)
-            }
-
-        private val abiOverrideField = get<ReflectRepo>().getDeclaredField(
-            PackageInstaller.SessionParams::class.java,
-            "abiOverride"
-        )!!.also { field ->
-            field.isAccessible = true
-        }
-
-        var PackageInstaller.SessionParams.abiOverride: String?
-            get() = abiOverrideField.get(this) as? String
-            set(value) {
-                abiOverrideField.set(this, value)
-            }
+    private val installFlagsField = get<ReflectRepo>().getDeclaredField(
+        PackageInstaller.SessionParams::class.java,
+        "installFlags"
+    )!!.also { field ->
+        field.isAccessible = true
     }
+
+    var PackageInstaller.SessionParams.installFlags: Int
+        get() = installFlagsField.getInt(this)
+        set(value) {
+            installFlagsField.setInt(this, value)
+        }
+
+    private val abiOverrideField = get<ReflectRepo>().getDeclaredField(
+        PackageInstaller.SessionParams::class.java,
+        "abiOverride"
+    )!!.also { field ->
+        field.isAccessible = true
+    }
+
+    var PackageInstaller.SessionParams.abiOverride: String?
+        get() = abiOverrideField.get(this) as? String
+        set(value) {
+            abiOverrideField.set(this, value)
+        }
 }

--- a/app/src/main/java/com/rosan/installer/data/app/util/PackageManagerUtil.kt
+++ b/app/src/main/java/com/rosan/installer/data/app/util/PackageManagerUtil.kt
@@ -42,171 +42,169 @@ import com.rosan.installer.data.app.model.exception.UninstallFailedOwnerBlockedE
 import com.rosan.installer.data.app.model.exception.UninstallFailedUserRestrictedException
 import com.rosan.installer.data.app.model.impl.installer.IBinderInstallerRepoImpl
 
-class PackageManagerUtil {
-    companion object {
+object PackageManagerUtil {
+    /**
+     * Flag parameter for {@link #deletePackage} to indicate that you don't want to delete the
+     * package's data directory.
+     */
+    const val DELETE_KEEP_DATA = 0x00000001
 
-        /**
-         * Flag parameter for {@link #deletePackage} to indicate that you don't want to delete the
-         * package's data directory.
-         */
-        const val DELETE_KEEP_DATA = 0x00000001
+    /**
+     * Flag parameter for {@link #deletePackage} to indicate that you want the
+     * package deleted for all users.
+     */
+    const val DELETE_ALL_USERS = 0x00000002
 
-        /**
-         * Flag parameter for {@link #deletePackage} to indicate that you want the
-         * package deleted for all users.
-         */
-        const val DELETE_ALL_USERS = 0x00000002
+    /**
+     * Flag parameter for {@link #deletePackage} to indicate that, if you are calling
+     * uninstall on a system that has been updated, then don't do the normal process
+     * of uninstalling the update and rolling back to the older system version (which
+     * needs to happen for all users); instead, just mark the app as uninstalled for
+     * the current user.
+     */
+    const val DELETE_SYSTEM_APP = 0x00000004;
 
-        /**
-         * Flag parameter for {@link #deletePackage} to indicate that, if you are calling
-         * uninstall on a system that has been updated, then don't do the normal process
-         * of uninstalling the update and rolling back to the older system version (which
-         * needs to happen for all users); instead, just mark the app as uninstalled for
-         * the current user.
-         */
-        const val DELETE_SYSTEM_APP = 0x00000004;
+    const val INSTALL_FAILED_ALREADY_EXISTS = -1
+    const val INSTALL_FAILED_INVALID_APK = -2
+    const val INSTALL_FAILED_INVALID_URI = -3
+    const val INSTALL_FAILED_INSUFFICIENT_STORAGE = -4
+    const val INSTALL_FAILED_DUPLICATE_PACKAGE = -5
+    const val INSTALL_FAILED_NO_SHARED_USER = -6
+    const val INSTALL_FAILED_UPDATE_INCOMPATIBLE = -7
+    const val INSTALL_FAILED_SHARED_USER_INCOMPATIBLE = -8
+    const val INSTALL_FAILED_MISSING_SHARED_LIBRARY = -9
+    const val INSTALL_FAILED_REPLACE_COULDNT_DELETE = -10
+    const val INSTALL_FAILED_DEXOPT = -11
+    const val INSTALL_FAILED_OLDER_SDK = -12
+    const val INSTALL_FAILED_CONFLICTING_PROVIDER = -13
+    const val INSTALL_FAILED_NEWER_SDK = -14
+    const val INSTALL_FAILED_TEST_ONLY = -15
+    const val INSTALL_FAILED_CPU_ABI_INCOMPATIBLE = -16
+    const val INSTALL_FAILED_MISSING_FEATURE = -17
+    const val INSTALL_FAILED_CONTAINER_ERROR = -18
+    const val INSTALL_FAILED_INVALID_INSTALL_LOCATION = -19
+    const val INSTALL_FAILED_MEDIA_UNAVAILABLE = -20
+    const val INSTALL_FAILED_VERIFICATION_TIMEOUT = -21
+    const val INSTALL_FAILED_VERIFICATION_FAILURE = -22
+    const val INSTALL_FAILED_PACKAGE_CHANGED = -23
+    const val INSTALL_FAILED_UID_CHANGED = -24
+    const val INSTALL_FAILED_VERSION_DOWNGRADE = -25
+    const val INSTALL_FAILED_DEPRECATED_SDK_VERSION = -29
+    const val INSTALL_FAILED_INTERNAL_ERROR = -110
+    const val INSTALL_FAILED_USER_RESTRICTED = -111
+    const val INSTALL_FAILED_DUPLICATE_PERMISSION = -112
+    const val INSTALL_FAILED_NO_MATCHING_ABIS = -113
+    const val INSTALL_FAILED_REJECTED_BY_BUILDTYPE = -3001
+    const val INSTALL_FAILED_HYPEROS_ISOLATION_VIOLATION = -1000
 
-        const val INSTALL_FAILED_ALREADY_EXISTS = -1
-        const val INSTALL_FAILED_INVALID_APK = -2
-        const val INSTALL_FAILED_INVALID_URI = -3
-        const val INSTALL_FAILED_INSUFFICIENT_STORAGE = -4
-        const val INSTALL_FAILED_DUPLICATE_PACKAGE = -5
-        const val INSTALL_FAILED_NO_SHARED_USER = -6
-        const val INSTALL_FAILED_UPDATE_INCOMPATIBLE = -7
-        const val INSTALL_FAILED_SHARED_USER_INCOMPATIBLE = -8
-        const val INSTALL_FAILED_MISSING_SHARED_LIBRARY = -9
-        const val INSTALL_FAILED_REPLACE_COULDNT_DELETE = -10
-        const val INSTALL_FAILED_DEXOPT = -11
-        const val INSTALL_FAILED_OLDER_SDK = -12
-        const val INSTALL_FAILED_CONFLICTING_PROVIDER = -13
-        const val INSTALL_FAILED_NEWER_SDK = -14
-        const val INSTALL_FAILED_TEST_ONLY = -15
-        const val INSTALL_FAILED_CPU_ABI_INCOMPATIBLE = -16
-        const val INSTALL_FAILED_MISSING_FEATURE = -17
-        const val INSTALL_FAILED_CONTAINER_ERROR = -18
-        const val INSTALL_FAILED_INVALID_INSTALL_LOCATION = -19
-        const val INSTALL_FAILED_MEDIA_UNAVAILABLE = -20
-        const val INSTALL_FAILED_VERIFICATION_TIMEOUT = -21
-        const val INSTALL_FAILED_VERIFICATION_FAILURE = -22
-        const val INSTALL_FAILED_PACKAGE_CHANGED = -23
-        const val INSTALL_FAILED_UID_CHANGED = -24
-        const val INSTALL_FAILED_VERSION_DOWNGRADE = -25
-        const val INSTALL_FAILED_DEPRECATED_SDK_VERSION = -29
-        const val INSTALL_FAILED_USER_RESTRICTED = -111
-        const val INSTALL_FAILED_DUPLICATE_PERMISSION = -112
-        const val INSTALL_FAILED_NO_MATCHING_ABIS = -113
-        const val INSTALL_FAILED_REJECTED_BY_BUILDTYPE = -3001
-        const val INSTALL_FAILED_HYPEROS_ISOLATION_VIOLATION = -1000
+    const val DELETE_FAILED_INTERNAL_ERROR = -1
+    const val DELETE_FAILED_DEVICE_POLICY_MANAGER = -2
+    const val DELETE_FAILED_USER_RESTRICTED = -3
+    const val DELETE_FAILED_OWNER_BLOCKED = -4
+    const val DELETE_FAILED_ABORTED = -5
+    const val DELETE_FAILED_HYPEROS_SYSTEM_APP = -1000
 
-        const val DELETE_FAILED_INTERNAL_ERROR = -1
-        const val DELETE_FAILED_DEVICE_POLICY_MANAGER = -2
-        const val DELETE_FAILED_USER_RESTRICTED = -3
-        const val DELETE_FAILED_OWNER_BLOCKED = -4
-        const val DELETE_FAILED_ABORTED = -5
-        const val DELETE_FAILED_HYPEROS_SYSTEM_APP = -1000
-
-        fun installResultVerify(
-            context: Context,
-            receiver: IBinderInstallerRepoImpl.LocalIntentReceiver
+    fun installResultVerify(
+        context: Context,
+        receiver: IBinderInstallerRepoImpl.LocalIntentReceiver
+    ) {
+        val intent = receiver.getResult()
+        val status =
+            intent.getIntExtra(PackageInstaller.EXTRA_STATUS, PackageInstaller.STATUS_FAILURE)
+        val action =
+            IntentCompat.getParcelableExtra(intent, Intent.EXTRA_INTENT, Intent::class.java)
+        if (status == PackageInstaller.STATUS_PENDING_USER_ACTION
+            && action != null
         ) {
-            val intent = receiver.getResult()
-            val status =
-                intent.getIntExtra(PackageInstaller.EXTRA_STATUS, PackageInstaller.STATUS_FAILURE)
-            val action =
-                IntentCompat.getParcelableExtra(intent, Intent.EXTRA_INTENT, Intent::class.java)
-            if (status == PackageInstaller.STATUS_PENDING_USER_ACTION
-                && action != null
-            ) {
-                context.startActivity(action.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
-                installResultVerify(context, receiver)
-                return
-            }
-            if (status == PackageInstaller.STATUS_SUCCESS) return
-            val legacyStatus = intent.getIntExtra(
-                PackageInstallerUtil.EXTRA_LEGACY_STATUS, PackageInstaller.STATUS_FAILURE
-            )
-            val msg = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
-            val ecpMsg = "Install Failure $status#$legacyStatus [$msg]"
-            throw when (legacyStatus) {
-                INSTALL_FAILED_ALREADY_EXISTS -> InstallFailedAlreadyExistsException(ecpMsg)
-                INSTALL_FAILED_INVALID_APK -> InstallFailedInvalidAPKException(ecpMsg)
-                INSTALL_FAILED_INVALID_URI -> InstallFailedInvalidURIException(ecpMsg)
-                INSTALL_FAILED_INSUFFICIENT_STORAGE -> InstallFailedInsufficientStorageException(ecpMsg)
-                INSTALL_FAILED_DUPLICATE_PACKAGE -> InstallFailedDuplicatePackageException(ecpMsg)
-                INSTALL_FAILED_DUPLICATE_PERMISSION -> InstallFailedDuplicatePermissionException(ecpMsg)
-                INSTALL_FAILED_NO_SHARED_USER -> InstallFailedNoSharedUserException(ecpMsg)
-                INSTALL_FAILED_UPDATE_INCOMPATIBLE -> InstallFailedUpdateIncompatibleException(ecpMsg)
-                INSTALL_FAILED_SHARED_USER_INCOMPATIBLE -> InstallFailedSharedUserIncompatibleException(ecpMsg)
-                INSTALL_FAILED_MISSING_SHARED_LIBRARY -> InstallFailedMissingSharedLibraryException(ecpMsg)
-                INSTALL_FAILED_REPLACE_COULDNT_DELETE -> InstallFailedReplaceCouldntDeleteException(ecpMsg)
-                INSTALL_FAILED_DEXOPT -> InstallFailedDexOptException(ecpMsg)
-                INSTALL_FAILED_OLDER_SDK -> InstallFailedOlderSdkException(ecpMsg)
-                INSTALL_FAILED_CONFLICTING_PROVIDER -> InstallFailedConflictingProviderException(ecpMsg)
-                INSTALL_FAILED_NEWER_SDK -> InstallFailedNewerSDKException(ecpMsg)
-                INSTALL_FAILED_TEST_ONLY -> InstallFailedTestOnlyException(ecpMsg)
-                INSTALL_FAILED_CPU_ABI_INCOMPATIBLE -> InstallFailedCpuAbiIncompatibleException(ecpMsg)
-                INSTALL_FAILED_NO_MATCHING_ABIS -> InstallFailedCpuAbiIncompatibleException(ecpMsg)
-                INSTALL_FAILED_MISSING_FEATURE -> InstallFailedMissingFeatureException(ecpMsg)
-                INSTALL_FAILED_CONTAINER_ERROR -> InstallFailedContainerErrorException(ecpMsg)
-                INSTALL_FAILED_INVALID_INSTALL_LOCATION -> InstallFailedInvalidInstallLocationException(ecpMsg)
-                INSTALL_FAILED_MEDIA_UNAVAILABLE -> InstallFailedMediaUnavailableException(ecpMsg)
-                INSTALL_FAILED_VERIFICATION_TIMEOUT -> InstallFailedVerificationTimeoutException(ecpMsg)
-                INSTALL_FAILED_VERIFICATION_FAILURE -> InstallFailedVerificationFailureException(ecpMsg)
-                INSTALL_FAILED_PACKAGE_CHANGED -> InstallFailedPackageChangedException(ecpMsg)
-                INSTALL_FAILED_UID_CHANGED -> InstallFailedUidChangedException(ecpMsg)
-                INSTALL_FAILED_VERSION_DOWNGRADE -> InstallFailedVersionDowngradeException(ecpMsg)
-                INSTALL_FAILED_DEPRECATED_SDK_VERSION -> InstallFailedDeprecatedSdkVersion(ecpMsg)
-                INSTALL_FAILED_REJECTED_BY_BUILDTYPE -> InstallFailedRejectedByBuildTypeException(ecpMsg)
-                INSTALL_FAILED_HYPEROS_ISOLATION_VIOLATION -> InstallFailedHyperOSIsolationViolationException(ecpMsg)
-                INSTALL_FAILED_USER_RESTRICTED -> InstallFailedUserRestrictedException(ecpMsg)
-                else -> IllegalStateException(ecpMsg)
-            }
+            context.startActivity(action.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+            installResultVerify(context, receiver)
+            return
         }
+        if (status == PackageInstaller.STATUS_SUCCESS) return
+        val legacyStatus = intent.getIntExtra(
+            PackageInstallerUtil.EXTRA_LEGACY_STATUS, PackageInstaller.STATUS_FAILURE
+        )
+        val msg = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
+        val ecpMsg = "Install Failure $status#$legacyStatus [$msg]"
+        throw when (legacyStatus) {
+            INSTALL_FAILED_ALREADY_EXISTS -> InstallFailedAlreadyExistsException(ecpMsg)
+            INSTALL_FAILED_INVALID_APK -> InstallFailedInvalidAPKException(ecpMsg)
+            INSTALL_FAILED_INVALID_URI -> InstallFailedInvalidURIException(ecpMsg)
+            INSTALL_FAILED_INSUFFICIENT_STORAGE -> InstallFailedInsufficientStorageException(ecpMsg)
+            INSTALL_FAILED_DUPLICATE_PACKAGE -> InstallFailedDuplicatePackageException(ecpMsg)
+            INSTALL_FAILED_DUPLICATE_PERMISSION -> InstallFailedDuplicatePermissionException(ecpMsg)
+            INSTALL_FAILED_NO_SHARED_USER -> InstallFailedNoSharedUserException(ecpMsg)
+            INSTALL_FAILED_UPDATE_INCOMPATIBLE -> InstallFailedUpdateIncompatibleException(ecpMsg)
+            INSTALL_FAILED_SHARED_USER_INCOMPATIBLE -> InstallFailedSharedUserIncompatibleException(ecpMsg)
+            INSTALL_FAILED_MISSING_SHARED_LIBRARY -> InstallFailedMissingSharedLibraryException(ecpMsg)
+            INSTALL_FAILED_REPLACE_COULDNT_DELETE -> InstallFailedReplaceCouldntDeleteException(ecpMsg)
+            INSTALL_FAILED_DEXOPT -> InstallFailedDexOptException(ecpMsg)
+            INSTALL_FAILED_OLDER_SDK -> InstallFailedOlderSdkException(ecpMsg)
+            INSTALL_FAILED_CONFLICTING_PROVIDER -> InstallFailedConflictingProviderException(ecpMsg)
+            INSTALL_FAILED_NEWER_SDK -> InstallFailedNewerSDKException(ecpMsg)
+            INSTALL_FAILED_TEST_ONLY -> InstallFailedTestOnlyException(ecpMsg)
+            INSTALL_FAILED_CPU_ABI_INCOMPATIBLE -> InstallFailedCpuAbiIncompatibleException(ecpMsg)
+            INSTALL_FAILED_NO_MATCHING_ABIS -> InstallFailedCpuAbiIncompatibleException(ecpMsg)
+            INSTALL_FAILED_MISSING_FEATURE -> InstallFailedMissingFeatureException(ecpMsg)
+            INSTALL_FAILED_CONTAINER_ERROR -> InstallFailedContainerErrorException(ecpMsg)
+            INSTALL_FAILED_INVALID_INSTALL_LOCATION -> InstallFailedInvalidInstallLocationException(ecpMsg)
+            INSTALL_FAILED_MEDIA_UNAVAILABLE -> InstallFailedMediaUnavailableException(ecpMsg)
+            INSTALL_FAILED_VERIFICATION_TIMEOUT -> InstallFailedVerificationTimeoutException(ecpMsg)
+            INSTALL_FAILED_VERIFICATION_FAILURE -> InstallFailedVerificationFailureException(ecpMsg)
+            INSTALL_FAILED_PACKAGE_CHANGED -> InstallFailedPackageChangedException(ecpMsg)
+            INSTALL_FAILED_UID_CHANGED -> InstallFailedUidChangedException(ecpMsg)
+            INSTALL_FAILED_VERSION_DOWNGRADE -> InstallFailedVersionDowngradeException(ecpMsg)
+            INSTALL_FAILED_DEPRECATED_SDK_VERSION -> InstallFailedDeprecatedSdkVersion(ecpMsg)
+            INSTALL_FAILED_REJECTED_BY_BUILDTYPE -> InstallFailedRejectedByBuildTypeException(ecpMsg)
+            INSTALL_FAILED_HYPEROS_ISOLATION_VIOLATION -> InstallFailedHyperOSIsolationViolationException(ecpMsg)
+            INSTALL_FAILED_USER_RESTRICTED -> InstallFailedUserRestrictedException(ecpMsg)
+            else -> IllegalStateException(ecpMsg)
+        }
+    }
 
-        /**
-         * Verifies the result from a PackageInstaller uninstall operation.
-         * This function mirrors installResultVerify but uses uninstall-specific
-         * error codes and exceptions.
-         *
-         * @param context The application context.
-         * @param receiver The LocalIntentReceiver that holds the result intent.
-         * @throws Exception with a detailed custom exception if the operation failed.
-         */
-        fun uninstallResultVerify(
-            context: Context,
-            receiver: IBinderInstallerRepoImpl.LocalIntentReceiver
+    /**
+     * Verifies the result from a PackageInstaller uninstall operation.
+     * This function mirrors installResultVerify but uses uninstall-specific
+     * error codes and exceptions.
+     *
+     * @param context The application context.
+     * @param receiver The LocalIntentReceiver that holds the result intent.
+     * @throws Exception with a detailed custom exception if the operation failed.
+     */
+    fun uninstallResultVerify(
+        context: Context,
+        receiver: IBinderInstallerRepoImpl.LocalIntentReceiver
+    ) {
+        val intent = receiver.getResult()
+        val status =
+            intent.getIntExtra(PackageInstaller.EXTRA_STATUS, PackageInstaller.STATUS_FAILURE)
+        val action =
+            IntentCompat.getParcelableExtra(intent, Intent.EXTRA_INTENT, Intent::class.java)
+        if (status == PackageInstaller.STATUS_PENDING_USER_ACTION
+            && action != null
         ) {
-            val intent = receiver.getResult()
-            val status =
-                intent.getIntExtra(PackageInstaller.EXTRA_STATUS, PackageInstaller.STATUS_FAILURE)
-            val action =
-                IntentCompat.getParcelableExtra(intent, Intent.EXTRA_INTENT, Intent::class.java)
-            if (status == PackageInstaller.STATUS_PENDING_USER_ACTION
-                && action != null
-            ) {
-                context.startActivity(action.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
-                // Recursively call to wait for the user's action result
-                uninstallResultVerify(context, receiver)
-                return
-            }
-            if (status == PackageInstaller.STATUS_SUCCESS) return
+            context.startActivity(action.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+            // Recursively call to wait for the user's action result
+            uninstallResultVerify(context, receiver)
+            return
+        }
+        if (status == PackageInstaller.STATUS_SUCCESS) return
 
-            val legacyStatus = intent.getIntExtra(
-                PackageInstallerUtil.EXTRA_LEGACY_STATUS, 0
-            )
-            val msg = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
-            val ecpMsg = "Uninstall Failure $status#$legacyStatus [$msg]"
+        val legacyStatus = intent.getIntExtra(
+            PackageInstallerUtil.EXTRA_LEGACY_STATUS, 0
+        )
+        val msg = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
+        val ecpMsg = "Uninstall Failure $status#$legacyStatus [$msg]"
 
-            // Map legacy uninstall status codes to specific exceptions
-            throw when (legacyStatus) {
-                DELETE_FAILED_DEVICE_POLICY_MANAGER -> UninstallFailedDevicePolicyManagerException(ecpMsg)
-                DELETE_FAILED_USER_RESTRICTED -> UninstallFailedUserRestrictedException(ecpMsg)
-                DELETE_FAILED_OWNER_BLOCKED -> UninstallFailedOwnerBlockedException(ecpMsg)
-                DELETE_FAILED_ABORTED -> UninstallFailedAbortedException(ecpMsg)
-                DELETE_FAILED_INTERNAL_ERROR -> UninstallFailedInternalErrorException(ecpMsg)
-                DELETE_FAILED_HYPEROS_SYSTEM_APP -> UninstallFailedHyperOSSystemAppException(ecpMsg)
-                else -> IllegalStateException(ecpMsg)
-            }
+        // Map legacy uninstall status codes to specific exceptions
+        throw when (legacyStatus) {
+            DELETE_FAILED_DEVICE_POLICY_MANAGER -> UninstallFailedDevicePolicyManagerException(ecpMsg)
+            DELETE_FAILED_USER_RESTRICTED -> UninstallFailedUserRestrictedException(ecpMsg)
+            DELETE_FAILED_OWNER_BLOCKED -> UninstallFailedOwnerBlockedException(ecpMsg)
+            DELETE_FAILED_ABORTED -> UninstallFailedAbortedException(ecpMsg)
+            DELETE_FAILED_INTERNAL_ERROR -> UninstallFailedInternalErrorException(ecpMsg)
+            DELETE_FAILED_HYPEROS_SYSTEM_APP -> UninstallFailedHyperOSSystemAppException(ecpMsg)
+            else -> IllegalStateException(ecpMsg)
         }
     }
 }

--- a/app/src/main/java/com/rosan/installer/data/app/util/SignatureUtils.kt
+++ b/app/src/main/java/com/rosan/installer/data/app/util/SignatureUtils.kt
@@ -1,0 +1,118 @@
+package com.rosan.installer.data.app.util
+
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.content.pm.Signature
+import android.os.Build
+import timber.log.Timber
+import java.security.MessageDigest
+
+/**
+ * A utility object for extracting and hashing application signatures.
+ * REFACTORED to handle unconventional file paths like file descriptors.
+ */
+object SignatureUtils {
+
+    private const val HASH_ALGORITHM = "SHA-256"
+
+    /**
+     * Gets the signature hash from an APK file path.
+     *
+     * @param context The application context.
+     * @param apkPath The absolute path to the APK file, which can be a regular path or a file descriptor path.
+     * @return The SHA-256 hash of the first signature, or null if it fails.
+     */
+    fun getApkSignatureHash(context: Context, apkPath: String): String? {
+        return try {
+            // MODIFIED: Now calls a dedicated helper for archive files.
+            val packageInfo = getPackageArchiveInfoFromPath(context, apkPath)
+            val signature = getFirstSignature(packageInfo)
+            signature?.let { hashSignature(it) }
+        } catch (e: Exception) {
+            // This will catch any exceptions, including the previous NameNotFoundException if something is wrong.
+            Timber.e(e, "Failed to get signature hash from APK: $apkPath")
+            null
+        }
+    }
+
+    /**
+     * Gets the signature hash from an already installed application.
+     *
+     * @param context The application context.
+     * @param packageName The package name of the installed app.
+     * @return The SHA-256 hash of the first signature, or null if not found or an error occurs.
+     */
+    fun getInstalledAppSignatureHash(context: Context, packageName: String): String? {
+        return try {
+            // MODIFIED: Now calls a dedicated helper for installed packages.
+            val packageInfo = getInstalledPackageInfo(context, packageName)
+            val signature = getFirstSignature(packageInfo)
+            signature?.let { hashSignature(it) }
+        } catch (e: PackageManager.NameNotFoundException) {
+            Timber.d("Package not found, can't get signature: $packageName")
+            null // This is an expected case, not an error.
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to get signature hash for installed package: $packageName")
+            null
+        }
+    }
+
+    /**
+     * Hashes a Signature object using SHA-256.
+     *
+     * @param signature The signature to hash.
+     * @return A hex string representation of the hash.
+     */
+    private fun hashSignature(signature: Signature): String {
+        val digest = MessageDigest.getInstance(HASH_ALGORITHM)
+        val hashBytes = digest.digest(signature.toByteArray())
+        return hashBytes.joinToString("") { "%02x".format(it) }
+    }
+
+    // REMOVED the faulty dual-purpose `getPackageInfo` function.
+
+    // NEW: A dedicated function to get PackageInfo from an APK file path.
+    @Suppress("DEPRECATION")
+    private fun getPackageArchiveInfoFromPath(context: Context, apkPath: String): PackageInfo? {
+        val pm = context.packageManager
+        val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            PackageManager.GET_SIGNING_CERTIFICATES
+        } else {
+            PackageManager.GET_SIGNATURES
+        }
+        // This method correctly handles ANY valid file path, including file descriptors.
+        return pm.getPackageArchiveInfo(apkPath, flags)
+    }
+
+    // NEW: A dedicated function to get PackageInfo from an installed package name.
+    @Suppress("DEPRECATION")
+    private fun getInstalledPackageInfo(context: Context, packageName: String): PackageInfo? {
+        val pm = context.packageManager
+        val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            PackageManager.GET_SIGNING_CERTIFICATES
+        } else {
+            PackageManager.GET_SIGNATURES
+        }
+        return pm.getPackageInfo(packageName, flags)
+    }
+
+    /**
+     * Safely extracts the first signature from a PackageInfo object.
+     * Handles both modern SigningInfo and legacy Signature[] arrays.
+     */
+    private fun getFirstSignature(packageInfo: PackageInfo?): Signature? {
+        packageInfo ?: return null
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            val signingInfo = packageInfo.signingInfo
+            if (signingInfo?.hasMultipleSigners() == true) {
+                signingInfo.apkContentsSigners?.firstOrNull()
+            } else {
+                signingInfo?.signingCertificateHistory?.firstOrNull()
+            }
+        } else {
+            @Suppress("DEPRECATION")
+            packageInfo.signatures?.firstOrNull()
+        }
+    }
+}

--- a/app/src/main/java/com/rosan/installer/data/installer/model/impl/installer/ActionHandler.kt
+++ b/app/src/main/java/com/rosan/installer/data/installer/model/impl/installer/ActionHandler.kt
@@ -104,7 +104,6 @@ class ActionHandler(scope: CoroutineScope, installer: InstallerRepo) :
         Timber.d("[id=${installer.id}] resolve: State has been reset. Emitting ProgressEntity.Resolving.")
         installer.progress.emit(ProgressEntity.InstallResolving)
 
-
         installer.config = try {
             resolveConfig(activity)
         } catch (e: Exception) {
@@ -114,6 +113,16 @@ class ActionHandler(scope: CoroutineScope, installer: InstallerRepo) :
             return
         }
         Timber.d("[id=${installer.id}] resolve: Config resolved. installMode=${installer.config.installMode}")
+
+        // Check for notification mode immediately after resolving config.
+        val isNotificationInstall = installer.config.installMode == ConfigEntity.InstallMode.Notification ||
+                installer.config.installMode == ConfigEntity.InstallMode.AutoNotification
+
+        if (isNotificationInstall) {
+            Timber.d("[id=${installer.id}] Notification mode detected early. Switching to background.")
+            // This will trigger the Activity to finish itself and the ForegroundInfoHandler to start showing notifications.
+            installer.background(true)
+        }
 
         if (installer.config.installMode == ConfigEntity.InstallMode.Ignore) {
             Timber.d("[id=${installer.id}] resolve: InstallMode is Ignore. Finishing task.")

--- a/app/src/main/java/com/rosan/installer/data/installer/model/impl/installer/ForegroundInfoHandler.kt
+++ b/app/src/main/java/com/rosan/installer/data/installer/model/impl/installer/ForegroundInfoHandler.kt
@@ -238,6 +238,7 @@ class ForegroundInfoHandler(scope: CoroutineScope, installer: InstallerRepo) :
             is ProgressEntity.InstallResolving -> onResolving(builder)
             is ProgressEntity.InstallResolvedFailed -> onResolvedFailed(builder)
             is ProgressEntity.InstallResolveSuccess -> onResolveSuccess(builder)
+            is ProgressEntity.InstallPreparing -> onPreparing(builder, progress)
             is ProgressEntity.InstallAnalysing -> onAnalysing(builder)
             is ProgressEntity.InstallAnalysedFailed -> onAnalysedFailed(builder)
             is ProgressEntity.InstallAnalysedSuccess -> onAnalysedSuccess(builder)
@@ -270,6 +271,11 @@ class ForegroundInfoHandler(scope: CoroutineScope, installer: InstallerRepo) :
 
     private fun onResolving(builder: NotificationCompat.Builder) =
         builder.setContentTitle(getString(R.string.installer_resolving))
+            .addAction(0, getString(R.string.cancel), finishIntent).build()
+
+    private fun onPreparing(builder: NotificationCompat.Builder, progress: ProgressEntity.InstallPreparing) =
+        builder.setContentTitle(getString(R.string.installer_prepare_install))
+            .setProgress(100, (progress.progress * 100).toInt(), progress.progress < 0)
             .addAction(0, getString(R.string.cancel), finishIntent).build()
 
     private fun onResolvedFailed(builder: NotificationCompat.Builder) =

--- a/app/src/main/java/com/rosan/installer/ui/page/installer/dialog/inner/InstallInfoDialog.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/installer/dialog/inner/InstallInfoDialog.kt
@@ -49,7 +49,7 @@ import androidx.compose.ui.unit.dp
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
 import com.rosan.installer.R
 import com.rosan.installer.data.app.model.entity.AppEntity
-import com.rosan.installer.data.app.util.InstalledAppInfo
+import com.rosan.installer.data.app.model.entity.InstalledAppInfo
 import com.rosan.installer.data.app.util.sortedBest
 import com.rosan.installer.data.installer.repo.InstallerRepo
 import com.rosan.installer.ui.icons.AppIcons

--- a/app/src/main/java/com/rosan/installer/ui/page/installer/dialog/inner/common.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/installer/dialog/inner/common.kt
@@ -35,7 +35,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.rosan.installer.build.RsConfig
 import com.rosan.installer.ui.icons.AppIcons
@@ -154,6 +156,49 @@ fun ErrorTextBlock(
             exit = fadeOut() + shrinkVertically()
         ) {
             suggestions()
+        }
+    }
+}
+
+/**
+ * A composable that displays a list of warnings in a styled block.
+ * The style is similar to ErrorTextBlock but without title or icons.
+ *
+ * @param warnings A list of pairs, where each pair contains the text string
+ * and the specific Color for that text.
+ * @param modifier Modifier for the root Column.
+ */
+@Composable
+fun WarningTextBlock(
+    warnings: List<Pair<String, Color>>,
+    modifier: Modifier = Modifier,
+) {
+    // Only display the block if there are warnings to show.
+    if (warnings.isNotEmpty()) {
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .background(MaterialTheme.colorScheme.errorContainer)
+                .padding(12.dp)
+        ) {
+            // Provide a default text color for the container.
+            CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onErrorContainer) {
+                warnings.forEachIndexed { index, (text, color) ->
+                    // Add a spacer between messages for readability.
+                    if (index > 0) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
+                    Text(
+                        text = text,
+                        // Use the specific color provided for the text,
+                        // otherwise fallback to the container's default color.
+                        color = if (color == Color.Unspecified) LocalContentColor.current else color,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/rosan/installer/util/LocaleUtil.kt
+++ b/app/src/main/java/com/rosan/installer/util/LocaleUtil.kt
@@ -2,11 +2,16 @@ package com.rosan.installer.util
 
 /**
  * Converts legacy Android language codes to their modern equivalents.
- * This logic is migrated from the original PackageUtil to ensure compatibility.
+ * This ensures compatibility with older and non-standard APK splits.
+ *
+ * Logic is from the PackageUtil.kt file in the PackageInstaller project.
+ * Under Apache License 2.0.
  *
  * @param this The legacy language code to be converted.
  * @return The modern language code.
  * @see <a href="https://developer.android.com/reference/java/util/Locale#legacy-language-codes">java.util.Locale#legacy-language-codes</a>
+ *  * @see <a href="https://github.com/vvb2060/PackageInstaller/blob/master/app/src/main/java/io/github/vvb2060/packageinstaller/model/PackageUtil.kt">PackageUtil</a>
+ * @see <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
  */
 fun String.convertLegacyLanguageCode(): String {
     return when (this) {

--- a/app/src/main/java/com/rosan/installer/util/SplitNameUtil.kt
+++ b/app/src/main/java/com/rosan/installer/util/SplitNameUtil.kt
@@ -73,27 +73,6 @@ private fun getLanguageDisplayName(code: String): String? {
 }
 
 /**
- * 识别常见的 ABI 名称并返回更具描述性的版本
- *
- * @param name ABI 名称
- * @return 描述性的 ABI 名称，如果无法识别则返回 null
- */
-private fun getAbiDisplayName(name: String): String? {
-    return when (name) {
-        "armeabi" -> "ARM (32-bit)"
-        "armeabi-v7a" -> "ARMv7a (32-bit)"
-        "armeabi_v7a" -> "ARMv7a (32-bit)"
-        "arm64-v8a" -> "ARMv8a (64-bit)"
-        "arm64_v8a" -> "ARMv8a (64-bit)"
-        "x86" -> "x86 (32-bit)"
-        "x86_64" -> "x86 (64-bit)"
-        "mips" -> "MIPS"
-        "mips64" -> "MIPS64"
-        else -> null
-    }
-}
-
-/**
  * 识别常见的屏幕密度(DPI)名称并返回更具描述性的版本。
  *
  * @param name DPI 名称

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -143,6 +143,9 @@
     <string name="cancel">取消</string>
     <string name="retry">重试</string>
     <string name="install">安装</string>
+    <string name="upgrade">升级</string>
+    <string name="reinstall">重新安装</string>
+    <string name="install_anyway">强制安装</string>
     <string name="uninstall">卸载</string>
     <string name="next">下一步</string>
     <string name="previous">上一步</string>
@@ -183,6 +186,8 @@
     <string name="installer_prepare_type_sidegrade">将变更当前版本的应用</string>
     <string name="installer_prepare_type_unarchive">将取消归档当前应用</string>
     <string name="installer_prepare_type_unknown_confirm">你确定要安装吗？</string>
+    <string name="installer_prepare_signature_mismatch">签名不一致！继续安装可能导致数据丢失或带来安全风险。</string>
+    <string name="installer_prepare_signature_unknown">无法验证应用签名，请谨慎操作。</string>
     <string name="installer_installing">安装中…</string>
     <string name="installer_install_failed">安装失败</string>
     <string name="installer_install_success">安装成功</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -135,6 +135,10 @@
     <string name="cancel">取消</string>
     <string name="retry">重試</string>
     <string name="install">安裝</string>
+    <string name="upgrade">升級</string>
+    <string name="reinstall">重新安裝</string>
+    <string name="install_anyway">強制安裝</string>
+    <string name="uninstall">解除安裝</string>
     <string name="next">下一步</string>
     <string name="previous">上一步</string>
     <string name="close">關閉</string>
@@ -174,6 +178,8 @@
     <string name="installer_prepare_type_sidegrade">將變更目前版本的應用程式</string>
     <string name="installer_prepare_type_unarchive">將取消歸檔目前應用程式</string>
     <string name="installer_prepare_type_unknown_confirm">您確定要安裝嗎？</string>
+    <string name="installer_prepare_signature_mismatch">簽名不一致！繼續安裝可能導致數據丟失或帶來安全風險。</string>
+    <string name="installer_prepare_signature_unknown">無法驗證應用簽名，請謹慎操作。</string>
     <string name="installer_installing">安裝中…</string>
     <string name="installer_install_failed">安裝失敗</string>
     <string name="installer_install_success">安裝成功</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,6 +149,9 @@
     <string name="cancel">Cancel</string>
     <string name="retry">Retry</string>
     <string name="install">Install</string>
+    <string name="upgrade">Upgrade</string>
+    <string name="reinstall">Reinstall</string>
+    <string name="install_anyway">Install Anyway</string>
     <string name="uninstall">Uninstall</string>
     <string name="next">Next</string>
     <string name="previous">Back</string>
@@ -189,6 +192,8 @@
     <string name="installer_prepare_type_sidegrade">Will change the current version of the app</string>
     <string name="installer_prepare_type_unarchive">Will unarchive the current app</string>
     <string name="installer_prepare_type_unknown_confirm">Are you sure you want to install?</string>
+    <string name="installer_prepare_signature_mismatch">Signature mismatch! Continuing installation may cause data loss or security risks.</string>
+    <string name="installer_prepare_signature_unknown">Unable to verify app signature, please proceed with caution.</string>
     <string name="installer_installing">Installing…</string>
     <string name="installer_install_failed">Install failed</string>
     <string name="installer_install_success">Install success</string>


### PR DESCRIPTION
This commit introduces app signature verification during the installation preparation phase and improves the user interface for displaying warnings.

Key changes:
- **Signature Verification:**
    - Added `SignatureUtils.kt` to extract and hash APK and installed app signatures.
    - `AppEntity.BaseEntity` now includes a `signatureHash` property.
    - `InstalledAppInfo` now includes `signatureHash` and `isSystemApp` properties.
    - `PackageAnalysisResult` now includes a `signatureMatchStatus` (MATCH, MISMATCH, NOT_INSTALLED, UNKNOWN_ERROR).
    - The analyser (`ApkAnalyserRepoImpl`, `AnalyserRepoImpl`) now calculates and compares signature hashes.
- **Enhanced Installation Warnings:**
    - The `InstallPrepareDialog` now displays specific warnings for:
        - Signature mismatch (critical warning).
        - Unknown signature.
        - SDK incompatibility (blocking error).
        - Downgrades.
    - A new `WarningTextBlock` composable is used to display these warnings with appropriate colors (error, tertiary).
    - Button text in `InstallPrepareDialog` now dynamically changes based on the situation (e.g., "Install", "Upgrade", "Reinstall", "Install Anyway", "Unarchive").
- **Refinements & Fixes:**
    - `PackageManagerUtil` and `PackageInstallerUtil` converted to `object` for singleton usage.
    - Removed unused `deduplicate()` from `AppEntityInfo.kt` and `getAbiDisplayName()` from `SplitNameUtil.kt`.
    - Corrected language code conversion in `RsConfig.kt` to use `convertLegacyLanguageCode` from `LocaleUtil.kt`.
    - Added new string resources for signature warnings and dynamic button labels.
    - Minor improvements to notification handling in `ForegroundInfoHandler` and `ActionHandler`.
    - Disabled "GrantAllRequestedPermissions" for Dhizuku authorizer as it's not supported.
    - `InstalledAppInfo.kt` is moved to `data/app/model/entity` package.