### PR TITLE
fix: ui adjustments & bug fixes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.POST_PROMOTED_NOTIFICATIONS" />
     <uses-permission
         android:name="android.permission.WRITE_SECURE_SETTINGS"
         tools:ignore="ProtectedPermissions" />
@@ -34,6 +35,7 @@
 
         <activity
             android:name="com.rosan.installer.ui.activity.SettingsActivity"
+            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"
             android:exported="true"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>

--- a/app/src/main/java/com/rosan/installer/data/app/model/entity/DataEntity.kt
+++ b/app/src/main/java/com/rosan/installer/data/app/model/entity/DataEntity.kt
@@ -1,23 +1,22 @@
 package com.rosan.installer.data.app.model.entity
 
-import android.annotation.SuppressLint
-import android.system.Os
-import android.system.OsConstants
+import android.net.Uri
 import java.io.File
-import java.io.FileDescriptor
-import java.io.FileInputStream
 import java.io.InputStream
 import java.util.zip.ZipFile
 import java.util.zip.ZipInputStream
 
-sealed class DataEntity(open var source: DataEntity? = null) {
+sealed class DataEntity(
+    open var source: DataEntity? = null,
+    open val originalUri: Uri? = null
+) {
     abstract fun getInputStream(): InputStream?
 
     fun getInputStreamWhileNotEmpty(): InputStream? = getInputStream() ?: source?.getInputStream()
 
     fun getSourceTop(): DataEntity = source?.getSourceTop() ?: this
 
-    class FileEntity(val path: String) : DataEntity() {
+    class FileEntity(val path: String, override val originalUri: Uri? = null) : DataEntity(originalUri = originalUri) {
         override fun getInputStream() = File(path).inputStream()
 
         override fun toString() = path
@@ -34,33 +33,33 @@ sealed class DataEntity(open var source: DataEntity? = null) {
         override fun toString() = "$parent!$name"
     }
 
-    class FileDescriptorEntity(private val pid: Int, private val descriptor: Int) : DataEntity() {
-        @SuppressLint("DiscouragedPrivateApi")
-        fun getFileDescriptor(): FileDescriptor? {
-            if (Os.getpid() != pid) return null
-            val fileDescriptor = FileDescriptor()
-            kotlin.runCatching { FileDescriptor::class.java.getDeclaredField("descriptor") }
-                .onSuccess {
-                    it.isAccessible = true
-                    it.set(fileDescriptor, descriptor)
-                }.onFailure {
-                    it.printStackTrace()
-                }
-            if (!fileDescriptor.valid()) return null
-            Os.lseek(fileDescriptor, 0, OsConstants.SEEK_SET)
-            return fileDescriptor
-        }
-
-        override fun getInputStream(): InputStream {
-            val fileDescriptor = getFileDescriptor()
-            if (fileDescriptor != null) {
-                return FileInputStream(fileDescriptor)
+    /*    class FileDescriptorEntity(private val pid: Int, private val descriptor: Int) : DataEntity() {
+            @SuppressLint("DiscouragedPrivateApi")
+            fun getFileDescriptor(): FileDescriptor? {
+                if (Os.getpid() != pid) return null
+                val fileDescriptor = FileDescriptor()
+                kotlin.runCatching { FileDescriptor::class.java.getDeclaredField("descriptor") }
+                    .onSuccess {
+                        it.isAccessible = true
+                        it.set(fileDescriptor, descriptor)
+                    }.onFailure {
+                        it.printStackTrace()
+                    }
+                if (!fileDescriptor.valid()) return null
+                Os.lseek(fileDescriptor, 0, OsConstants.SEEK_SET)
+                return fileDescriptor
             }
-            return File("/proc/$pid/fd/$descriptor").inputStream()
-        }
 
-        override fun toString() = "/proc/$pid/fd/$descriptor"
-    }
+            override fun getInputStream(): InputStream {
+                val fileDescriptor = getFileDescriptor()
+                if (fileDescriptor != null) {
+                    return FileInputStream(fileDescriptor)
+                }
+                return File("/proc/$pid/fd/$descriptor").inputStream()
+            }
+
+            override fun toString() = "/proc/$pid/fd/$descriptor"
+        }*/
 
     class ZipInputStreamEntity(val name: String, val parent: DataEntity) : DataEntity() {
         override fun getInputStream(): InputStream? {

--- a/app/src/main/java/com/rosan/installer/ui/activity/SettingsActivity.kt
+++ b/app/src/main/java/com/rosan/installer/ui/activity/SettingsActivity.kt
@@ -1,5 +1,6 @@
 package com.rosan.installer.ui.activity
 
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -15,15 +16,14 @@ class SettingsActivity : ComponentActivity(), KoinComponent {
     override fun onCreate(savedInstanceState: Bundle?) {
         // Enable edge-to-edge mode for immersive experience
         enableEdgeToEdge()
+        // Compat Navigation Bar color for Xiaomi Devices
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+            window.isNavigationBarContrastEnforced = false
         super.onCreate(savedInstanceState)
         setContent {
             // A surface based on material design theme.
             InstallerTheme {
-                Surface(
-                    modifier = Modifier.fillMaxSize()
-                ) {
-                    // Disable AgreementDialog for now
-                    // AgreementDialog()
+                Surface(modifier = Modifier.fillMaxSize()) {
                     SettingsPage()
                 }
             }

--- a/app/src/main/java/com/rosan/installer/ui/theme/InstallerTheme.kt
+++ b/app/src/main/java/com/rosan/installer/ui/theme/InstallerTheme.kt
@@ -1,8 +1,6 @@
 package com.rosan.installer.ui.theme
 
-import android.app.Activity
 import android.os.Build
-import android.view.View
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialExpressiveTheme
@@ -12,9 +10,7 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
 
 private val LightColorScheme = lightColorScheme(
     primary = primaryLight,
@@ -84,13 +80,11 @@ private val DarkColorScheme = darkColorScheme(
 @Composable
 fun InstallerTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    // 添加动态颜色支持：仅对 Android 12 (API 31) 及以上版本有效
     dynamicColor: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S,
     content: @Composable () -> Unit
 ) {
     val context = LocalContext.current
     val colorScheme = when {
-        // 添加版本检查
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
             if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
         }
@@ -99,8 +93,6 @@ fun InstallerTheme(
         else -> LightColorScheme
     }
 
-    // New Status Bar Color Logic
-    val view = LocalView.current
     // TODO not needed since targetSDK 35
     /*if (!view.isInEditMode) {
         SideEffect {
@@ -109,28 +101,10 @@ fun InstallerTheme(
         }
     }*/
 
-    DisableNavigationBarContrast(view)
-
     MaterialExpressiveTheme(
         colorScheme = colorScheme,
         motionScheme = MotionScheme.expressive(),
         typography = Typography,
         content = content
     )
-}
-
-/**
- * Disable navigation bar contrast enforcement.
- * This is useful for devices where the navigation bar color should not be enforced
- * to match the system theme, allowing for custom colors.
- */
-@Composable
-fun DisableNavigationBarContrast(view: View) {
-    val view = LocalView.current
-    if (!view.isInEditMode) {
-        SideEffect {
-            val window = (view.context as Activity).window
-            window.isNavigationBarContrastEnforced = false
-        }
-    }
 }

--- a/app/src/main/res/values-v29/themes.xml
+++ b/app/src/main/res/values-v29/themes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="Theme.Installer" parent="Theme.Material3.DayNight">
+        <!--    Compat Navigation Bar Color when ModalBottomSheet activated    -->
+        <item name="android:enforceNavigationBarContrast">false</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,17 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Installer" parent="Theme.Material3.DayNight">
-        <!--    Compat Navigation Bar Color when ModalBottomSheet activated    -->
-        <item name="android:enforceNavigationBarContrast">false</item>
-    </style>
+    <style name="Theme.Installer" parent="Theme.Material3.DayNight" />
 
     <style name="Theme.Installer.Translucent" parent="Theme.Installer">
         <item name="android:windowIsTranslucent">true</item>
         <!--沉浸状态栏和导航栏-->
-        <!--  use enableEdgeToEdge() instead  -->
-        <!--        <pkg name="android:windowTranslucentStatus">true</pkg>
-                <pkg name="android:windowTranslucentNavigation">true</pkg>-->
         <item name="android:windowBackground">@android:color/transparent</item>
     </style>
 </resources>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 # distributionUrl=https\://mirrors.cloud.tencent.com/gradle/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true


### PR DESCRIPTION
This commit introduces several improvements to the installer:

- Enhances the zero-copy mechanism by attempting to reopen and stream directly from the original content URI if the initial access was through a `/proc` path. This avoids potential issues with short-lived `/proc` file descriptors.
- Modifies `DataEntity.FileEntity` to store the `originalUri` when applicable.
- Ensures that cached file descriptors obtained during data analysis are closed promptly after the analysis is complete.
- Removes the unused `FileDescriptorEntity` class.
- Adds the `POST_PROMOTED_NOTIFICATIONS` permission.
- Updates Gradle wrapper to version 8.14.3.
- Closes #162 #175 