### PR TITLE
feat: support installing apk to a dedicated user

### DIFF
--- a/app/schemas/com.rosan.installer.data.settings.model.room.InstallerRoom/7.json
+++ b/app/schemas/com.rosan.installer.data.settings.model.room.InstallerRoom/7.json
@@ -1,0 +1,240 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 7,
+    "identityHash": "0ca598bbbdc7b05d2b7bd3910194dcbd",
+    "entities": [
+      {
+        "tableName": "app",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `package_name` TEXT, `config_id` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, FOREIGN KEY(`config_id`) REFERENCES `config`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "package_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "configId",
+            "columnName": "config_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_app_package_name",
+            "unique": true,
+            "columnNames": [
+              "package_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_app_package_name` ON `${TABLE_NAME}` (`package_name`)"
+          },
+          {
+            "name": "index_app_config_id",
+            "unique": false,
+            "columnNames": [
+              "config_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_config_id` ON `${TABLE_NAME}` (`config_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "config",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "config_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "config",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL DEFAULT 'Default', `description` TEXT NOT NULL, `authorizer` TEXT NOT NULL, `customize_authorizer` TEXT NOT NULL, `install_mode` TEXT NOT NULL, `installer` TEXT, `enable_customize_user` INTEGER NOT NULL DEFAULT 0, `target_user_id` INTEGER NOT NULL DEFAULT 0, `enable_manual_dexopt` INTEGER NOT NULL DEFAULT 0, `force_dexopt` INTEGER NOT NULL DEFAULT 0, `dexopt_mode` TEXT NOT NULL DEFAULT 'speed-profile', `auto_delete` INTEGER NOT NULL, `display_sdk` INTEGER NOT NULL DEFAULT 0, `for_all_user` INTEGER NOT NULL, `allow_test_only` INTEGER NOT NULL, `allow_downgrade` INTEGER NOT NULL, `allow_restricted_permissions` INTEGER NOT NULL DEFAULT 0, `bypass_low_target_sdk` INTEGER NOT NULL DEFAULT 0, `allow_all_requested_permissions` INTEGER NOT NULL DEFAULT 0, `created_at` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Default'"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorizer",
+            "columnName": "authorizer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customizeAuthorizer",
+            "columnName": "customize_authorizer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installMode",
+            "columnName": "install_mode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installer",
+            "columnName": "installer",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "enableCustomizeUser",
+            "columnName": "enable_customize_user",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "targetUserId",
+            "columnName": "target_user_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "enableManualDexopt",
+            "columnName": "enable_manual_dexopt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "forceDexopt",
+            "columnName": "force_dexopt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "dexoptMode",
+            "columnName": "dexopt_mode",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'speed-profile'"
+          },
+          {
+            "fieldPath": "autoDelete",
+            "columnName": "auto_delete",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displaySdk",
+            "columnName": "display_sdk",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "forAllUser",
+            "columnName": "for_all_user",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "allowTestOnly",
+            "columnName": "allow_test_only",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "allowDowngrade",
+            "columnName": "allow_downgrade",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "allowRestrictedPermissions",
+            "columnName": "allow_restricted_permissions",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "bypassLowTargetSdk",
+            "columnName": "bypass_low_target_sdk",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "allowAllRequestedPermissions",
+            "columnName": "allow_all_requested_permissions",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '0ca598bbbdc7b05d2b7bd3910194dcbd')"
+    ]
+  }
+}

--- a/app/src/main/aidl/com/rosan/installer/IPrivilegedService.aidl
+++ b/app/src/main/aidl/com/rosan/installer/IPrivilegedService.aidl
@@ -70,4 +70,11 @@ interface IPrivilegedService {
      * @return {@code true} if the permission is granted, {@code false} otherwise.
      */
     boolean isPermissionGranted(String packageName, String permission);
+
+    /**
+     * Retrieves a list of all users on the device.
+     *
+     * @return A Map where the key is the integer user ID and the value is the user's name.
+     */
+    Map getUsers();
 }

--- a/app/src/main/java/com/rosan/installer/data/app/model/impl/installer/IBinderInstallerRepoImpl.kt
+++ b/app/src/main/java/com/rosan/installer/data/app/model/impl/installer/IBinderInstallerRepoImpl.kt
@@ -185,20 +185,22 @@ abstract class IBinderInstallerRepoImpl : InstallerRepo, KoinComponent {
         sharedUserIdBlacklist: List<String>,
         sharedUserIdExemption: List<String>
     ) {
-        // Blacklisted package names
-        if (managedBlacklistPackages.contains(packageName)) {
-            Timber.w("Installation blocked for $packageName because it is in the blacklist.")
-            throw InstallFailedBlacklistedPackageException("Installation blocked for $packageName because it is in the blacklist.")
-        }
+        if (!config.bypassBlacklistInstallSetByUser) {
+            // Blacklisted package names
+            if (managedBlacklistPackages.contains(packageName)) {
+                Timber.w("Installation blocked for $packageName because it is in the blacklist.")
+                throw InstallFailedBlacklistedPackageException("Installation blocked for $packageName because it is in the blacklist.")
+            }
 
-        // Blacklisted SharedUserID
-        // We can simply take the first entity's sharedUserId because they are all the same.
-        val sharedUid = entities.firstOrNull()?.sharedUserId
+            // Blacklisted SharedUserID
+            // We can simply take the first entity's sharedUserId because they are all the same.
+            val sharedUid = entities.firstOrNull()?.sharedUserId
 
-        if (sharedUid != null) {
-            if (sharedUserIdBlacklist.contains(sharedUid) && !sharedUserIdExemption.contains(packageName)) {
-                Timber.w("Installation blocked for $packageName because its sharedUserId '$sharedUid' is blacklisted.")
-                throw InstallFailedBlacklistedPackageException("Installation blocked for $packageName because its sharedUserId '$sharedUid' is blacklisted.")
+            if (sharedUid != null) {
+                if (sharedUserIdBlacklist.contains(sharedUid) && !sharedUserIdExemption.contains(packageName)) {
+                    Timber.w("Installation blocked for $packageName because its sharedUserId '$sharedUid' is blacklisted.")
+                    throw InstallFailedBlacklistedPackageException("Installation blocked for $packageName because its sharedUserId '$sharedUid' is blacklisted.")
+                }
             }
         }
 

--- a/app/src/main/java/com/rosan/installer/data/app/repo/PrivilegedActionRepo.kt
+++ b/app/src/main/java/com/rosan/installer/data/app/repo/PrivilegedActionRepo.kt
@@ -76,4 +76,11 @@ interface PrivilegedActionRepo {
      * @return True if the activity was successfully started, false otherwise.
      */
     suspend fun startActivityPrivileged(config: ConfigEntity, intent: Intent): Boolean
+
+    /**
+     * Fetches all users from the system.
+     * @param authorizer The authorizer to use for the check.
+     * @return A map of user IDs to their display names.
+     */
+    suspend fun getUsers(authorizer: ConfigEntity.Authorizer): Map<Int, String>
 }

--- a/app/src/main/java/com/rosan/installer/data/installer/model/impl/installer/ActionHandler.kt
+++ b/app/src/main/java/com/rosan/installer/data/installer/model/impl/installer/ActionHandler.kt
@@ -277,10 +277,21 @@ class ActionHandler(scope: CoroutineScope, installer: InstallerRepo) :
                     )
                 }
 
+            val targetUserId = if (installer.config.enableCustomizeUser) {
+                // Use UserId from profile if enableCustomizeUser is true
+                Timber.d("Custom user is enabled. Installing for user: ${installer.config.targetUserId}")
+                installer.config.targetUserId
+            } else {
+                // Otherwise, use the current userId instead
+                val currentUserId = Os.getuid() / 100000
+                Timber.d("Custom user is disabled. Installing for current user: $currentUserId")
+                currentUserId
+            }
+
             installEntities(
                 installer.config,
                 entitiesToInstall, // Pass the newly constructed list to the installer backend.
-                InstallExtraInfoEntity(Os.getuid() / 100000, cacheDirectory),
+                InstallExtraInfoEntity(targetUserId, cacheDirectory),
                 packageBlacklist,
                 sharedUserIdBlacklist,
                 sharedUserIdExemption

--- a/app/src/main/java/com/rosan/installer/data/recycle/model/entity/DhizukuPrivilegedService.kt
+++ b/app/src/main/java/com/rosan/installer/data/recycle/model/entity/DhizukuPrivilegedService.kt
@@ -126,4 +126,9 @@ class DhizukuPrivilegedService : BasePrivilegedService() {
             return false
         }
     }
+
+    override fun getUsers(): Map<Int, String> {
+        // TODO temporarily not necessary for dhizuku
+        return emptyMap()
+    }
 }

--- a/app/src/main/java/com/rosan/installer/data/recycle/model/impl/ShizukuUserServiceRecycler.kt
+++ b/app/src/main/java/com/rosan/installer/data/recycle/model/impl/ShizukuUserServiceRecycler.kt
@@ -51,6 +51,22 @@ object ShizukuUserServiceRecycler : Recycler<ShizukuUserServiceRecycler.UserServ
         override fun getPrivilegedService(): IPrivilegedService = privileged
     }
 
+    /**
+     * Creates a system-level [Context] for operations that require elevated privileges.
+     *
+     * This method attempts to obtain the system context via reflection on the
+     * `ActivityThread` class, then creates a package context as the `com.android.shell` user.
+     * If any part of this process fails, it falls back to the provided [fallbackContext].
+     *
+     * Logic is from the ShellInterface.kt file in the InstallWithOptions project.
+     * Under MIT License.
+     *
+     * @param fallbackContext The fallback context to return if system context creation fails.
+     * @return A [Context] instance for `com.android.shell`, or [fallbackContext] if an error occurs.
+     *
+     * @see <a href="https://github.com/zacharee/InstallWithOptions/blob/main/app/src/main/java/dev/zwander/installwithoptions/util/ShellInterface.kt">ShellInterface</a>
+     * @see <a href="https://github.com/zacharee/InstallWithOptions/blob/main/LICENSE">MIT License</a>
+     */
     private fun createSystemContext(fallbackContext: Context): Context {
         try {
             // Get system context

--- a/app/src/main/java/com/rosan/installer/data/recycle/model/impl/ShizukuUserServiceRecycler.kt
+++ b/app/src/main/java/com/rosan/installer/data/recycle/model/impl/ShizukuUserServiceRecycler.kt
@@ -4,12 +4,14 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.ServiceConnection
 import android.os.IBinder
+import android.os.Process
+import android.os.UserHandle
 import androidx.annotation.Keep
 import com.rosan.installer.IPrivilegedService
 import com.rosan.installer.IShizukuUserService
 import com.rosan.installer.data.recycle.model.entity.DefaultPrivilegedService
-import com.rosan.installer.data.recycle.repo.recyclable.UserService
 import com.rosan.installer.data.recycle.repo.Recycler
+import com.rosan.installer.data.recycle.repo.recyclable.UserService
 import com.rosan.installer.data.recycle.util.requireShizukuPermissionGranted
 import com.rosan.installer.di.init.processModules
 import kotlinx.coroutines.channels.awaitClose
@@ -21,6 +23,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.koin.core.context.startKoin
 import rikka.shizuku.Shizuku
+import timber.log.Timber
 import kotlin.system.exitProcess
 
 object ShizukuUserServiceRecycler : Recycler<ShizukuUserServiceRecycler.UserServiceProxy>(),
@@ -35,7 +38,7 @@ object ShizukuUserServiceRecycler : Recycler<ShizukuUserServiceRecycler.UserServ
         init {
             startKoin {
                 modules(processModules)
-                androidContext(context)
+                androidContext(createSystemContext(context))
             }
         }
 
@@ -48,6 +51,46 @@ object ShizukuUserServiceRecycler : Recycler<ShizukuUserServiceRecycler.UserServ
         override fun getPrivilegedService(): IPrivilegedService = privileged
     }
 
+    private fun createSystemContext(fallbackContext: Context): Context {
+        try {
+            // Get system context
+            val activityThreadClass = Class.forName("android.app.ActivityThread")
+            val systemMain = activityThreadClass.getMethod("systemMain").invoke(null)
+            val systemContext = activityThreadClass.getMethod("getSystemContext").invoke(systemMain) as Context
+
+            val userId = try {
+                UserHandle::class.java.getMethod("myUserId").invoke(null) as Int
+            } catch (e: Exception) {
+                Timber.tag("ShizukuUserService").e(e, "Failed to get userId")
+                Process.myUid() / 100000
+            }
+
+            val userHandle = Class.forName("android.os.UserHandle")
+            val userHandleConstructor = userHandle.getConstructor(Int::class.java)
+            val userHandleInstance = userHandleConstructor.newInstance(userId)
+
+            val context = systemContext.javaClass.getMethod(
+                "createPackageContextAsUser",
+                String::class.java,
+                Int::class.java,
+                userHandle
+            ).invoke(
+                systemContext,
+                "com.android.shell",
+                Context.CONTEXT_INCLUDE_CODE or Context.CONTEXT_IGNORE_SECURITY,
+                userHandleInstance
+            ) as Context
+
+            val finalContext = context.createPackageContext("com.android.shell", 0)
+            Timber.tag("ShizukuUserService").d("Created system context: ${finalContext.packageName}, UID: ${Process.myUid()}")
+            return finalContext
+        } catch (e: Exception) {
+            Timber.tag("ShizukuUserService").e(e, "Failed to create system context: ${e.message}")
+            Timber.tag("ShizukuUserService").d("Falling back to app context: ${fallbackContext.packageName}")
+            return fallbackContext
+        }
+    }
+
     private val context by inject<Context>()
 
     override fun onMake(): UserServiceProxy = runBlocking {
@@ -57,22 +100,23 @@ object ShizukuUserServiceRecycler : Recycler<ShizukuUserServiceRecycler.UserServ
     }
 
     private suspend fun onInnerMake(): UserServiceProxy = callbackFlow {
-        Shizuku.bindUserService(Shizuku.UserServiceArgs(
-            ComponentName(
-                context, ShizukuUserService::class.java
-            )
-        ).processNameSuffix("shizuku_privileged"), object : ServiceConnection {
-            override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
-                trySend(UserServiceProxy(IShizukuUserService.Stub.asInterface(service)))
-                service?.linkToDeath({
-                    if (entity?.service == service) recycleForcibly()
-                }, 0)
-            }
+        Shizuku.bindUserService(
+            Shizuku.UserServiceArgs(
+                ComponentName(
+                    context, ShizukuUserService::class.java
+                )
+            ).processNameSuffix("shizuku_privileged"), object : ServiceConnection {
+                override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+                    trySend(UserServiceProxy(IShizukuUserService.Stub.asInterface(service)))
+                    service?.linkToDeath({
+                        if (entity?.service == service) recycleForcibly()
+                    }, 0)
+                }
 
-            override fun onServiceDisconnected(name: ComponentName?) {
-                close()
-            }
-        })
+                override fun onServiceDisconnected(name: ComponentName?) {
+                    close()
+                }
+            })
         awaitClose { }
     }.first()
 }

--- a/app/src/main/java/com/rosan/installer/data/recycle/util/UserServiceUtil.kt
+++ b/app/src/main/java/com/rosan/installer/data/recycle/util/UserServiceUtil.kt
@@ -68,6 +68,7 @@ private fun getRecyclableInstance(
     special: (() -> String?)?
 ): Recyclable<out UserService>? {
     // special為null，或special.invoke()時，遵循config
+    Timber.tag("PrivilegedService").d("Authorizer: $authorizer")
     return if (special?.invoke() == null) when (authorizer) {
         ConfigEntity.Authorizer.Root -> ProcessUserServiceRecyclers.get("su").make()
         ConfigEntity.Authorizer.Shizuku -> ShizukuUserServiceRecycler.make()

--- a/app/src/main/java/com/rosan/installer/data/settings/model/room/InstallerRoom.kt
+++ b/app/src/main/java/com/rosan/installer/data/settings/model/room/InstallerRoom.kt
@@ -23,14 +23,15 @@ import org.koin.core.component.get
 
 @Database(
     entities = [AppEntity::class, ConfigEntity::class],
-    version = 6,
+    version = 7,
     exportSchema = true,
     autoMigrations = [
         /*        AutoMigration(from = 1, to = 2),
                 AutoMigration(from = 2, to = 3, spec = InstallerRoom.AUTO_MIGRATION_2_3::class),*/
         AutoMigration(from = 3, to = 4),
         AutoMigration(from = 4, to = 5),
-        AutoMigration(from = 5, to = 6)
+        AutoMigration(from = 5, to = 6),
+        AutoMigration(from = 6, to = 7),
     ]
 )
 @TypeConverters(

--- a/app/src/main/java/com/rosan/installer/data/settings/model/room/entity/ConfigEntity.kt
+++ b/app/src/main/java/com/rosan/installer/data/settings/model/room/entity/ConfigEntity.kt
@@ -21,6 +21,8 @@ data class ConfigEntity(
     @ColumnInfo(name = "customize_authorizer") var customizeAuthorizer: String,
     @ColumnInfo(name = "install_mode") var installMode: InstallMode,
     @ColumnInfo(name = "installer") var installer: String?,
+    @ColumnInfo(name = "enable_customize_user", defaultValue = "0") var enableCustomizeUser: Boolean = false,
+    @ColumnInfo(name = "target_user_id", defaultValue = "0") var targetUserId: Int = 0,
     @ColumnInfo(name = "enable_manual_dexopt", defaultValue = "0") var enableManualDexopt: Boolean = false,
     @ColumnInfo(name = "force_dexopt", defaultValue = "0") var forceDexopt: Boolean = false,
     @ColumnInfo(
@@ -45,6 +47,8 @@ data class ConfigEntity(
             customizeAuthorizer = "",
             installMode = InstallMode.Global,
             installer = null,
+            enableCustomizeUser = false,
+            targetUserId = 0,
             enableManualDexopt = false,
             forceDexopt = false,
             dexoptMode = DexoptMode.SpeedProfile,
@@ -53,7 +57,7 @@ data class ConfigEntity(
             allowTestOnly = false,
             allowDowngrade = false,
             allowRestrictedPermissions = true,
-            bypassLowTargetSdk = false,
+            bypassLowTargetSdk = true,
             allowAllRequestedPermissions = false,
         )
 
@@ -63,6 +67,8 @@ data class ConfigEntity(
             customizeAuthorizer = "",
             installMode = InstallMode.Global,
             installer = "com.miui.packageinstaller",
+            enableCustomizeUser = false,
+            targetUserId = 0,
             enableManualDexopt = false,
             forceDexopt = false,
             dexoptMode = DexoptMode.SpeedProfile,
@@ -71,7 +77,7 @@ data class ConfigEntity(
             allowTestOnly = false,
             allowDowngrade = false,
             allowRestrictedPermissions = true,
-            bypassLowTargetSdk = false,
+            bypassLowTargetSdk = true,
             allowAllRequestedPermissions = false,
         )
     }

--- a/app/src/main/java/com/rosan/installer/data/settings/model/room/entity/ConfigEntity.kt
+++ b/app/src/main/java/com/rosan/installer/data/settings/model/room/entity/ConfigEntity.kt
@@ -86,6 +86,9 @@ data class ConfigEntity(
     var installFlags: Int = 0
 
     @Ignore
+    var bypassBlacklistInstallSetByUser: Boolean = false
+
+    @Ignore
     var uninstallFlags: Int = 0
 
     val isCustomizeAuthorizer: Boolean

--- a/app/src/main/java/com/rosan/installer/data/settings/util/ConfigUtil.kt
+++ b/app/src/main/java/com/rosan/installer/data/settings/util/ConfigUtil.kt
@@ -38,6 +38,12 @@ class ConfigUtil {
             return AuthorizerConverter.revert(str)
         }
 
+        suspend fun ConfigEntity.Authorizer.readGlobal() =
+            if (this == ConfigEntity.Authorizer.Global)
+                getGlobalAuthorizer()
+            else
+                this
+
         suspend fun getGlobalCustomizeAuthorizer(): String {
             return appDataStore.getString(AppDataStore.CUSTOMIZE_AUTHORIZER, "").first()
         }

--- a/app/src/main/java/com/rosan/installer/di/viewmodel_module.kt
+++ b/app/src/main/java/com/rosan/installer/di/viewmodel_module.kt
@@ -12,7 +12,7 @@ import org.koin.dsl.module
 
 val viewModelModule = module {
     viewModel { (installer: InstallerRepo) ->
-        DialogViewModel(installer, get(), get())
+        DialogViewModel(installer, get(), get(), get())
     }
 
     viewModel {
@@ -24,7 +24,7 @@ val viewModelModule = module {
     }
 
     viewModel { (id: Long?) ->
-        EditViewModel(get(), get(), id)
+        EditViewModel(get(), get(), get(), id)
     }
 
     viewModel { (id: Long) ->

--- a/app/src/main/java/com/rosan/installer/ui/icons/AppIcons.kt
+++ b/app/src/main/java/com/rosan/installer/ui/icons/AppIcons.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.SmartDisplay
 import androidx.compose.material.icons.outlined.Tag
 import androidx.compose.material.icons.outlined.WebAsset
+import androidx.compose.material.icons.twotone.AccountCircle
 import androidx.compose.material.icons.twotone.Add
 import androidx.compose.material.icons.twotone.AdminPanelSettings
 import androidx.compose.material.icons.twotone.Android
@@ -115,6 +116,7 @@ object AppIcons {
     // --- 设置图标结束 ---
 
     // --- Profile pkg 图标集合 ---
+    val InstallUser = Icons.TwoTone.AccountCircle
     val InstallSource = Icons.TwoTone.Face
     val InstallSourceInput = Icons.TwoTone.Badge
     val InstallForAllUsers = Icons.TwoTone.People

--- a/app/src/main/java/com/rosan/installer/ui/page/main/installer/dialog/DialogViewAction.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/installer/dialog/DialogViewAction.kt
@@ -31,6 +31,12 @@ sealed class DialogViewAction {
     data class SetInstaller(val installer: String?) : DialogViewAction()
 
     /**
+     * Sets the target user ID.
+     * @param userId The target user ID.
+     */
+    data class SetTargetUser(val userId: Int) : DialogViewAction()
+
+    /**
      * Toggles a specific flag for the uninstallation process.
      * @param flag The flag to toggle, e.g., DELETE_KEEP_DATA.
      * @param enable true to add the flag, false to remove it.

--- a/app/src/main/java/com/rosan/installer/ui/page/main/installer/dialog/DialogViewModel.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/installer/dialog/DialogViewModel.kt
@@ -15,6 +15,7 @@ import com.rosan.installer.R
 import com.rosan.installer.data.app.model.entity.AppEntity
 import com.rosan.installer.data.app.model.entity.PackageAnalysisResult
 import com.rosan.installer.data.app.repo.AppIconRepo
+import com.rosan.installer.data.app.repo.PARepo
 import com.rosan.installer.data.app.util.InstallOption
 import com.rosan.installer.data.app.util.PackageManagerUtil
 import com.rosan.installer.data.installer.model.entity.InstallResult
@@ -25,7 +26,9 @@ import com.rosan.installer.data.installer.repo.InstallerRepo
 import com.rosan.installer.data.settings.model.datastore.AppDataStore
 import com.rosan.installer.data.settings.model.datastore.entity.NamedPackage
 import com.rosan.installer.data.settings.model.room.entity.ConfigEntity
+import com.rosan.installer.data.settings.util.ConfigUtil.Companion.getGlobalAuthorizer
 import com.rosan.installer.ui.page.main.installer.dialog.inner.UiText
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,6 +37,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import timber.log.Timber
@@ -41,7 +45,8 @@ import timber.log.Timber
 class DialogViewModel(
     private var repo: InstallerRepo,
     private val appDataStore: AppDataStore,
-    private val appIconRepo: AppIconRepo
+    private val appIconRepo: AppIconRepo,
+    private val paRepo: PARepo
 ) : ViewModel(), KoinComponent {
     private val context by inject<Context>()
 
@@ -66,15 +71,15 @@ class DialogViewModel(
     var versionCompareInSingleLine by mutableStateOf(false)
         private set
 
-    // 用于显示批量安装的进度文本
+    // Text to show in the progress bar
     private val _installProgressText = MutableStateFlow<UiText?>(null)
     val installProgressText: StateFlow<UiText?> = _installProgressText.asStateFlow()
 
-    // 用于驱动进度条的数值进度 (0.0f to 1.0f)
+    // Progress to drive the progress bar
     private val _installProgress = MutableStateFlow<Float?>(null)
     val installProgress: StateFlow<Float?> = _installProgress.asStateFlow()
 
-    // 批量安装队列和结果
+    // Queue and result for multi-install scenarios
     private var multiInstallQueue: List<SelectInstallEntity> = emptyList()
     private val multiInstallResults = mutableListOf<InstallResult>()
     private var currentMultiInstallIndex = 0
@@ -92,9 +97,6 @@ class DialogViewModel(
             else -> true
         }
 
-    //private val _preInstallAppInfo = MutableStateFlow<InstalledAppInfo?>(null)
-    //val preInstallAppInfo: StateFlow<InstalledAppInfo?> = _preInstallAppInfo.asStateFlow()
-
     private val _currentPackageName = MutableStateFlow<String?>(null)
     val currentPackageName: StateFlow<String?> = _currentPackageName.asStateFlow()
 
@@ -107,7 +109,7 @@ class DialogViewModel(
     val installFlags: StateFlow<Int> = _installFlags.asStateFlow()
 
     // StateFlow to hold the default installer package name from global settings.
-    private val _defaultInstallerFromSettings = MutableStateFlow<String?>(repo.config.installer)
+    private val _defaultInstallerFromSettings = MutableStateFlow(repo.config.installer)
     val defaultInstallerFromSettings: StateFlow<String?> = _defaultInstallerFromSettings.asStateFlow()
 
     // StateFlow to hold the list of managed installer packages.
@@ -117,6 +119,14 @@ class DialogViewModel(
     // StateFlow to hold the currently selected installer package name.
     private val _selectedInstaller = MutableStateFlow(repo.config.installer)
     val selectedInstaller: StateFlow<String?> = _selectedInstaller.asStateFlow()
+
+    // StateFlow to hold the list of available users.
+    private val _availableUsers = MutableStateFlow<Map<Int, String>>(emptyMap())
+    val availableUsers: StateFlow<Map<Int, String>> = _availableUsers.asStateFlow()
+
+    // StateFlow to hold the currently selected user ID.
+    private val _selectedUserId = MutableStateFlow(0)
+    val selectedUserId: StateFlow<Int> = _selectedUserId.asStateFlow()
 
     /**
      * Holds information about the app to be uninstalled.
@@ -142,7 +152,6 @@ class DialogViewModel(
      */
     private var isRetryingInstall = false
 
-    //private var fetchPreInstallInfoJob: Job? = null
     private val iconJobs = mutableMapOf<String, Job>()
     private var autoInstallJob: Job? = null
     private var collectRepoJob: Job? = null
@@ -163,6 +172,8 @@ class DialogViewModel(
             appDataStore.getNamedPackageList(AppDataStore.MANAGED_INSTALLER_PACKAGES_LIST).collect { packages ->
                 _managedInstallerPackages.value = packages
             }
+            // Load available users for target user selection.
+            _availableUsers.value = paRepo.getUsers(repo.config.authorizer.getAuthorizer())
         }
     }
 
@@ -203,11 +214,21 @@ class DialogViewModel(
             }
 
             is DialogViewAction.SetInstaller -> selectInstaller(action.installer)
+            is DialogViewAction.SetTargetUser -> selectTargetUser(action.userId)
         }
     }
 
     private fun collectRepo(repo: InstallerRepo) {
         this.repo = repo
+        // Load available users for target user selection.
+        viewModelScope.launch {
+            // Switch to the IO dispatcher for the blocking call
+            val users = withContext(Dispatchers.IO) {
+                paRepo.getUsers(repo.config.authorizer.getAuthorizer())
+            }
+            // The code below this line will execute back on the Main dispatcher
+            _availableUsers.value = users
+        }
         // initialize install flags based on repo.config
         _installFlags.value = listOfNotNull(
             repo.config.allowTestOnly.takeIf { it }
@@ -370,10 +391,6 @@ class DialogViewModel(
                 }
 
                 if (newState is DialogViewState.InstallPrepare && previousState !is DialogViewState.InstallPrepare) {
-                    /*if (_currentPackageName.value != null && (_preInstallAppInfo.value == null || _preInstallAppInfo.value?.packageName != _currentPackageName.value)) {
-                        fetchPreInstallAppInfo(_currentPackageName.value!!)
-                    }*/
-
                     if (repo.config.installMode == ConfigEntity.InstallMode.AutoDialog) {
                         autoInstallJob?.cancel()
                         autoInstallJob = viewModelScope.launch {
@@ -391,6 +408,12 @@ class DialogViewModel(
             }
         }
     }
+
+    private suspend fun ConfigEntity.Authorizer.getAuthorizer() =
+        if (this == ConfigEntity.Authorizer.Global)
+            getGlobalAuthorizer()
+        else
+            this
 
     /**
      * 切换（启用/禁用）一个安装标志位
@@ -412,6 +435,11 @@ class DialogViewModel(
     private fun selectInstaller(packageName: String?) {
         repo.config.installer = packageName // Update the repository
         _selectedInstaller.value = packageName // Update the StateFlow
+    }
+
+    private fun selectTargetUser(userId: Int) {
+        repo.config.targetUserId = userId
+        _selectedUserId.value = userId
     }
 
     /**
@@ -471,40 +499,6 @@ class DialogViewModel(
         }
     }
 
-    /*private fun fetchPreInstallAppInfo(packageName: String) {
-        if (packageName.isBlank()) {
-            _preInstallAppInfo.value = null
-            return
-        }
-        if (fetchPreInstallInfoJob?.isActive == true && _currentPackageName.value == packageName) {
-            return
-        }
-        if (_preInstallAppInfo.value != null && _preInstallAppInfo.value?.packageName == packageName) {
-            return
-        }
-
-        fetchPreInstallInfoJob?.cancel()
-        fetchPreInstallInfoJob = viewModelScope.launch {
-            val packageNameAtFetchStart = packageName
-            val info = try {
-                withContext(Dispatchers.IO) {
-                    InstalledAppInfo.buildByPackageName(packageNameAtFetchStart)
-                }
-            } catch (e: Exception) {
-                null
-            }
-
-            // 只在状态不是最终状态（成功/失败）时更新 preInstallAppInfo
-            // 并且包名仍然匹配
-            if (state !is DialogViewState.InstallSuccess &&
-                state !is DialogViewState.InstallFailed &&
-                _currentPackageName.value == packageNameAtFetchStart
-            ) {
-                _preInstallAppInfo.value = info
-            }
-        }
-    }*/
-
     fun toast(message: String) {
         Toast.makeText(context, message, Toast.LENGTH_LONG).show()
     }
@@ -515,9 +509,7 @@ class DialogViewModel(
 
     private fun close() {
         autoInstallJob?.cancel()
-        //fetchPreInstallInfoJob?.cancel()
         collectRepoJob?.cancel()
-        //_preInstallAppInfo.value = null
         _currentPackageName.value = null
         iconJobs.values.forEach { it.cancel() }
         iconJobs.clear()

--- a/app/src/main/java/com/rosan/installer/ui/page/main/installer/dialog/DialogViewModel.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/installer/dialog/DialogViewModel.kt
@@ -246,17 +246,11 @@ class DialogViewModel(
         ).fold(0) { acc, flag -> acc or flag }
         // sync to repo.config
         repo.config.installFlags = _installFlags.value
-        // When collecting for the first time, save the original list for multi-install restoration.
-        /*if (originalAnalysisResults.isEmpty()) {
-            originalAnalysisResults = repo.analysisResults
-        }*/
-        //_preInstallAppInfo.value = null
         _currentPackageName.value = null
         val newPackageNames = repo.analysisResults.map { it.packageName }.toSet()
         _displayIcons.update { old -> old.filterKeys { it in newPackageNames } }
         collectRepoJob?.cancel()
         autoInstallJob?.cancel()
-        //fetchPreInstallInfoJob?.cancel()
 
         collectRepoJob = viewModelScope.launch {
             repo.progress.collect { progress ->

--- a/app/src/main/java/com/rosan/installer/ui/page/main/installer/dialog/inner/InstallExtendedMenuAction.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/installer/dialog/inner/InstallExtendedMenuAction.kt
@@ -1,10 +1,11 @@
 package com.rosan.installer.ui.page.main.installer.dialog.inner
 
 sealed class InstallExtendedMenuAction {
-    object PermissionList : InstallExtendedMenuAction()
-    object CustomizeInstaller : InstallExtendedMenuAction()
-    object InstallOption : InstallExtendedMenuAction()
-    object TextField : InstallExtendedMenuAction()
+    data object PermissionList : InstallExtendedMenuAction()
+    data object CustomizeInstaller : InstallExtendedMenuAction()
+    data object CustomizeUser : InstallExtendedMenuAction()
+    data object InstallOption : InstallExtendedMenuAction()
+    data object TextField : InstallExtendedMenuAction()
 }
 
 sealed class InstallExtendedSubMenuId(val id: String) {

--- a/app/src/main/java/com/rosan/installer/ui/page/main/installer/dialog/inner/InstallFailedDialog.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/installer/dialog/inner/InstallFailedDialog.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import com.rosan.installer.R
 import com.rosan.installer.build.Manufacturer
 import com.rosan.installer.build.RsConfig
+import com.rosan.installer.data.app.model.exception.InstallFailedBlacklistedPackageException
 import com.rosan.installer.data.app.model.exception.InstallFailedConflictingProviderException
 import com.rosan.installer.data.app.model.exception.InstallFailedDeprecatedSdkVersion
 import com.rosan.installer.data.app.model.exception.InstallFailedHyperOSIsolationViolationException
@@ -232,6 +233,18 @@ private fun ErrorSuggestions(
                     },
                     labelRes = R.string.suggestion_bypass_low_target_sdk,
                     icon = AppIcons.InstallBypassLowTargetSdk
+                )
+            )
+            add(
+                SuggestionChipInfo(
+                    InstallFailedBlacklistedPackageException::class,
+                    selected = { true }, // This is an action, not a state toggle.
+                    onClick = {
+                        viewModel.toggleBypassBlacklist(true)
+                        viewModel.dispatch(DialogViewAction.Install)
+                    },
+                    labelRes = R.string.suggestion_bypass_blacklist_set_by_user,
+                    icon = AppIcons.BugReport
                 )
             )
         }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/edit/EditPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/edit/EditPage.kt
@@ -54,6 +54,7 @@ import com.rosan.installer.ui.page.main.widget.setting.DataForAllUserWidget
 import com.rosan.installer.ui.page.main.widget.setting.DataInstallModeWidget
 import com.rosan.installer.ui.page.main.widget.setting.DataManualDexoptWidget
 import com.rosan.installer.ui.page.main.widget.setting.DataNameWidget
+import com.rosan.installer.ui.page.main.widget.setting.DataUserWidget
 import com.rosan.installer.ui.page.main.widget.setting.DisplaySdkWidget
 import com.rosan.installer.ui.page.main.widget.setting.LabelWidget
 import com.rosan.installer.ui.theme.none
@@ -206,7 +207,7 @@ fun EditPage(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(it),
-            state = listState, // 关键: 将 state 传入 LazyColumn
+            state = listState,
         ) {
             item { DataNameWidget(viewModel = viewModel) }
             item { DataDescriptionWidget(viewModel = viewModel) }
@@ -214,6 +215,7 @@ fun EditPage(
             item { DataCustomizeAuthorizerWidget(viewModel = viewModel) }
             item { DataInstallModeWidget(viewModel = viewModel) }
             item { LabelWidget(label = stringResource(R.string.config_label_installer_settings)) }
+            item { DataUserWidget(viewModel) }
             item { DataDeclareInstallerWidget(viewModel = viewModel) }
             item { DataManualDexoptWidget(viewModel) }
             item { DataAutoDeleteWidget(viewModel = viewModel) }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/edit/EditViewAction.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/edit/EditViewAction.kt
@@ -11,6 +11,8 @@ sealed class EditViewAction {
     data class ChangeDataInstallMode(val installMode: ConfigEntity.InstallMode) : EditViewAction()
     data class ChangeDataDeclareInstaller(val declareInstaller: Boolean) : EditViewAction()
     data class ChangeDataInstaller(val installer: String) : EditViewAction()
+    data class ChangeDataCustomizeUser(val enable: Boolean) : EditViewAction()
+    data class ChangeDataTargetUserId(val userId: Int) : EditViewAction()
     data class ChangeDataEnableManualDexopt(val enable: Boolean) : EditViewAction()
     data class ChangeDataForceDexopt(val force: Boolean) : EditViewAction()
     data class ChangeDataDexoptMode(val mode: ConfigEntity.DexoptMode) : EditViewAction()

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/edit/EditViewState.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/edit/EditViewState.kt
@@ -5,7 +5,8 @@ import com.rosan.installer.data.settings.model.room.entity.ConfigEntity
 
 data class EditViewState(
     val data: Data = Data.build(ConfigEntity.default),
-    val managedInstallerPackages: List<NamedPackage> = emptyList()
+    val managedInstallerPackages: List<NamedPackage> = emptyList(),
+    val availableUsers: Map<Int, String> = emptyMap()
 ) {
     data class Data(
         val name: String,
@@ -15,6 +16,8 @@ data class EditViewState(
         val installMode: ConfigEntity.InstallMode,
         val declareInstaller: Boolean,
         val installer: String,
+        val enableCustomizeUser: Boolean,
+        val targetUserId: Int,
         val enableManualDexopt: Boolean,
         val forceDexopt: Boolean,
         val dexoptMode: ConfigEntity.DexoptMode,
@@ -42,6 +45,8 @@ data class EditViewState(
             customizeAuthorizer = if (this.authorizerCustomize) this.customizeAuthorizer else "",
             installMode = this.installMode,
             installer = if (this.declareInstaller) this.installer else null,
+            enableCustomizeUser = this.enableCustomizeUser,
+            targetUserId = this.targetUserId,
             enableManualDexopt = this.enableManualDexopt,
             dexoptMode = this.dexoptMode,
             forceDexopt = this.forceDexopt,
@@ -64,6 +69,8 @@ data class EditViewState(
                 installMode = config.installMode,
                 declareInstaller = config.installer != null,
                 installer = config.installer ?: "",
+                enableCustomizeUser = config.enableCustomizeUser,
+                targetUserId = config.targetUserId,
                 enableManualDexopt = config.enableManualDexopt,
                 forceDexopt = config.forceDexopt,
                 dexoptMode = config.dexoptMode,

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/edit/NewEditPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/edit/NewEditPage.kt
@@ -62,6 +62,7 @@ import com.rosan.installer.ui.page.main.widget.setting.DataForAllUserWidget
 import com.rosan.installer.ui.page.main.widget.setting.DataInstallModeWidget
 import com.rosan.installer.ui.page.main.widget.setting.DataManualDexoptWidget
 import com.rosan.installer.ui.page.main.widget.setting.DataNameWidget
+import com.rosan.installer.ui.page.main.widget.setting.DataUserWidget
 import com.rosan.installer.ui.page.main.widget.setting.DisplaySdkWidget
 import com.rosan.installer.ui.page.main.widget.setting.SplicedColumnGroup
 import com.rosan.installer.ui.theme.none
@@ -262,6 +263,7 @@ fun NewEditPage(
                 SplicedColumnGroup(
                     title = stringResource(R.string.config_label_installer_settings),
                     content = buildList {
+                        add { DataUserWidget(viewModel) }
                         add { DataDeclareInstallerWidget(viewModel) }
                         add { DataManualDexoptWidget(viewModel) }
                         add { DataAutoDeleteWidget(viewModel) }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/widget/setting/EditItemWidget.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/widget/setting/EditItemWidget.kt
@@ -196,7 +196,7 @@ fun DataDeclareInstallerWidget(viewModel: EditViewModel) {
 
     val description =
         if (isDhizuku) stringResource(R.string.dhizuku_cannot_set_installer_desc)
-        else null // 其他模式下没有特殊描述
+        else null
 
     SwitchWidget(
         icon = AppIcons.InstallSource,
@@ -306,16 +306,30 @@ fun DataInstallerWidget(viewModel: EditViewModel) {
 
 @Composable
 fun DataUserWidget(viewModel: EditViewModel) {
+    val stateAuthorizer = viewModel.state.data.authorizer
+    val globalAuthorizer = viewModel.globalAuthorizer
     val enableCustomizeUser = viewModel.state.data.enableCustomizeUser
     val targetUserId = viewModel.state.data.targetUserId
-    val availableUsers = viewModel.state.availableUsers // 从 ViewModel 获取用户列表
+    val availableUsers = viewModel.state.availableUsers
+
+    val isDhizuku = when (stateAuthorizer) {
+        ConfigEntity.Authorizer.Dhizuku -> true
+        ConfigEntity.Authorizer.Global -> globalAuthorizer == ConfigEntity.Authorizer.Dhizuku
+        else -> false
+    }
+
+    val description =
+        if (isDhizuku) stringResource(R.string.dhizuku_cannot_set_user_desc)
+        else stringResource(id = R.string.config_customize_user_desc)
 
     Column {
         SwitchWidget(
-            icon = AppIcons.InstallUser, // 你可能需要一个新图标
+            icon = AppIcons.InstallUser,
             title = stringResource(id = R.string.config_customize_user),
-            description = stringResource(id = R.string.config_customize_user_desc),
+            description = description,
             checked = enableCustomizeUser,
+            enabled = !isDhizuku,
+            isError = isDhizuku,
             onCheckedChange = {
                 viewModel.dispatch(EditViewAction.ChangeDataCustomizeUser(it))
             }
@@ -343,11 +357,26 @@ fun DataUserWidget(viewModel: EditViewModel) {
 
 @Composable
 fun DataManualDexoptWidget(viewModel: EditViewModel) {
+    val stateAuthorizer = viewModel.state.data.authorizer
+    val globalAuthorizer = viewModel.globalAuthorizer
+
+    val isDhizuku = when (stateAuthorizer) {
+        ConfigEntity.Authorizer.Dhizuku -> true
+        ConfigEntity.Authorizer.Global -> globalAuthorizer == ConfigEntity.Authorizer.Dhizuku
+        else -> false
+    }
+
+    val description =
+        if (isDhizuku) stringResource(R.string.dhizuku_cannot_set_dexopt_desc)
+        else stringResource(R.string.config_manual_dexopt_desc)
+
     SwitchWidget(
         icon = Icons.TwoTone.Speed,
         title = stringResource(id = R.string.config_manual_dexopt),
-        description = stringResource(id = R.string.config_manual_dexopt_desc),
+        description = description,
         checked = viewModel.state.data.enableManualDexopt,
+        enabled = !isDhizuku,
+        isError = isDhizuku,
         onCheckedChange = {
             viewModel.dispatch(EditViewAction.ChangeDataEnableManualDexopt(it))
         }
@@ -500,4 +529,3 @@ fun DataAllowAllRequestedPermissionsWidget(viewModel: EditViewModel) {
         onCheckedChange = { viewModel.dispatch(EditViewAction.ChangeDataAllowAllRequestedPermissions(it)) }
     )
 }
-

--- a/app/src/main/java/com/rosan/installer/ui/page/main/widget/setting/EditItemWidget.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/widget/setting/EditItemWidget.kt
@@ -305,6 +305,43 @@ fun DataInstallerWidget(viewModel: EditViewModel) {
 }
 
 @Composable
+fun DataUserWidget(viewModel: EditViewModel) {
+    val enableCustomizeUser = viewModel.state.data.enableCustomizeUser
+    val targetUserId = viewModel.state.data.targetUserId
+    val availableUsers = viewModel.state.availableUsers // 从 ViewModel 获取用户列表
+
+    Column {
+        SwitchWidget(
+            icon = AppIcons.InstallUser, // 你可能需要一个新图标
+            title = stringResource(id = R.string.config_customize_user),
+            description = stringResource(id = R.string.config_customize_user_desc),
+            checked = enableCustomizeUser,
+            onCheckedChange = {
+                viewModel.dispatch(EditViewAction.ChangeDataCustomizeUser(it))
+            }
+        )
+
+        AnimatedVisibility(
+            visible = enableCustomizeUser,
+            enter = expandVertically() + fadeIn(),
+            exit = shrinkVertically() + fadeOut()
+        ) {
+            val description = availableUsers[targetUserId] ?: stringResource(R.string.config_user_not_found)
+            DropDownMenuWidget(
+                title = stringResource(R.string.config_target_user),
+                description = description,
+                choice = availableUsers.keys.toList().indexOf(targetUserId),
+                data = availableUsers.values.toList(),
+            ) { index ->
+                availableUsers.keys.toList().getOrNull(index)?.let {
+                    viewModel.dispatch(EditViewAction.ChangeDataTargetUserId(it))
+                }
+            }
+        }
+    }
+}
+
+@Composable
 fun DataManualDexoptWidget(viewModel: EditViewModel) {
     SwitchWidget(
         icon = Icons.TwoTone.Speed,

--- a/app/src/main/java/com/rosan/installer/ui/page/main/widget/setting/NumberPickerWidget.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/widget/setting/NumberPickerWidget.kt
@@ -101,5 +101,6 @@ fun IntNumberPickerWidget(
             Spacer(modifier = Modifier.width(16.dp))
             Text(text = value.toString())
         }
+        Spacer(modifier = Modifier.size(8.dp))
     }
 }

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/config/all/MiuixAllPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/config/all/MiuixAllPage.kt
@@ -342,7 +342,7 @@ private fun DataItemWidget(
                     Spacer(modifier = Modifier.width(4.dp))
                     Text(
                         modifier = Modifier.padding(end = 3.dp),
-                        text = "作用域",
+                        text = stringResource(R.string.config_scope),
                         color = MiuixTheme.colorScheme.onSurface.copy(alpha = if (isSystemInDarkTheme()) 0.7f else 0.9f),
                         fontWeight = FontWeight.Medium,
                         fontSize = 15.sp

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/config/apply/MiuixApplyPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/config/apply/MiuixApplyPage.kt
@@ -110,7 +110,7 @@ fun MiuixApplyPage(
             Column {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,
-                    title = stringResource(R.string.app),
+                    title = stringResource(R.string.config_scope),
                     navigationIcon = {
                         MiuixBackButton(
                             modifier = Modifier.padding(start = 16.dp),

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/config/edit/MiuixEditPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/config/edit/MiuixEditPage.kt
@@ -38,6 +38,7 @@ import com.rosan.installer.ui.page.miuix.widgets.MiuixDataForAllUserWidget
 import com.rosan.installer.ui.page.miuix.widgets.MiuixDataInstallModeWidget
 import com.rosan.installer.ui.page.miuix.widgets.MiuixDataManualDexoptWidget
 import com.rosan.installer.ui.page.miuix.widgets.MiuixDataNameWidget
+import com.rosan.installer.ui.page.miuix.widgets.MiuixDataUserWidget
 import com.rosan.installer.ui.page.miuix.widgets.MiuixDisplaySdkWidget
 import com.rosan.installer.ui.page.miuix.widgets.MiuixUnsavedChangesDialog
 import com.rosan.installer.ui.theme.none
@@ -170,6 +171,7 @@ fun MiuixEditPage(
                         .padding(horizontal = 12.dp)
                         .padding(bottom = 6.dp)
                 ) {
+                    MiuixDataUserWidget(viewModel = viewModel)
                     MiuixDataDeclareInstallerWidget(viewModel = viewModel)
                     MiuixDataManualDexoptWidget(viewModel)
                     MiuixDataAutoDeleteWidget(viewModel = viewModel)

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -18,7 +18,7 @@
     <string name="menu">القائمة</string>
     <string name="about">حول</string>
     <string name="other">أخرى</string>
-    <string name="about_detail">حول InstallerX</string>
+    <string name="about_detail">حول InstallerX Revived</string>
     <string name="get_update">الحصول على تحديث</string>
     <string name="get_update_detail">التحقق من وجود تحديثات للبرنامج وميزات جديدة.</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -18,7 +18,7 @@
     <string name="menu">Menú</string>
     <string name="about">Acerca de</string>
     <string name="other">Otro</string>
-    <string name="about_detail">Acerca de InstallerX</string>
+    <string name="about_detail">Acerca de InstallerX Revived</string>
     <string name="get_update">Obtener actualización</string>
     <string name="get_update_detail">Buscar actualizaciones de software y nuevas funciones.</string>
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -17,7 +17,7 @@
     <string name="menu">Menu</string>
     <string name="about">Sobre</string>
     <string name="other">Outro</string>
-    <string name="about_detail">Sobre o InstallerX</string>
+    <string name="about_detail">Sobre o InstallerX Revived</string>
     <string name="get_update">Atualizar</string>
     <string name="get_update_detail">Verificar por novas atualizações e funcionalidades.</string>
     <string name="internet_access_enabled">Online</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8' ?>
 <resources>
     <string name="about">О приложении </string>
-    <string name="about_detail">Об InstallerX</string>
+    <string name="about_detail">Об InstallerX Revived</string>
     <string name="add">Добавить</string>
     <string name="allocate_aggressive">Выделять Агрессивные</string>
     <string name="allocate_aggressive_desc">Указывает, что пакет "критически важен для работоспособности или безопасности системы" и при необходимости будет более агрессивно удалять доступные для очистки файлы, чтобы освободить место.</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="about">เกี่ยวกับ</string>
-    <string name="about_detail">เกี่ยวกับ InstallerX</string>
+    <string name="about_detail">เกี่ยวกับ InstallerX Revived</string>
     <string name="add">เพิ่ม</string>
     <string name="allocate_aggressive">จัดสรรอย่างเข้มข้น</string>
     <string name="allocate_aggressive_desc">ระบุว่าแพ็คเกจเป็น ส่วนสำคัญต่อสุขภาพหรือความปลอดภัยของระบบ และจะลบไฟล์ที่ล้างได้มากขึ้นเพื่อเพิ่มพื้นที่หากจำเป็น</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -16,7 +16,7 @@
     <string name="menu">Меню</string>
     <string name="about">Про застосунок</string>
     <string name="other">Інше</string>
-    <string name="about_detail">Про InstallerX</string>
+    <string name="about_detail">Про InstallerX Revived</string>
     <string name="get_update">Отримувати оновлення</string>
     <string name="get_update_detail">Перевіряти наявність оновлень ПЗ та нових функцій.</string>
     <string name="internet_access_enabled">У мережі</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -85,6 +85,7 @@
     <string name="order">排序</string>
     <string name="config_name">名称</string>
     <string name="config_info">信息</string>
+    <string name="config_scope">作用域</string>
     <string name="config_description">描述</string>
     <string name="config_authorizer">授权器</string>
     <!--    <string name="config_authorizer_msg">用于执行解析与执行命令，请确保拥有足够的权限。</string>-->
@@ -428,4 +429,5 @@
     <string name="suggestion_mi_isolation">临时添加有效安装者并重试</string>
     <string name="suggestion_user_restricted">前往开发者选项启用USB安装</string>
     <string name="suggestion_bypass_low_target_sdk">临时允许绕过限制并重试</string>
+    <string name="suggestion_bypass_blacklist_set_by_user">本次允许安装</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -331,7 +331,9 @@
     <string name="close_notification_immediately_on_dialog_dismiss">关闭对话框将静默退出</string>
     <string name="set_countdown">设定倒计时</string>
     <string name="dhizuku_auto_close_countdown_desc">Dhizuku安装成功后自动关闭的倒计时</string>
-    <string name="dhizuku_cannot_set_installer_desc">Dhizuku 模式下不支持设置安装器！</string>
+    <string name="dhizuku_cannot_set_installer_desc">Dhizuku模式下不支持设置安装器！</string>
+    <string name="dhizuku_cannot_set_user_desc">Dhizuku模式下不支持设置用户！</string>
+    <string name="dhizuku_cannot_set_dexopt_desc">Dhizuku模式下不支持设置DexOpt！</string>
     <string name="grant_permission_after_install">点击以在安装完成后授予权限</string>
     <string name="show_intelligent_suggestion">显示智能建议（实验性）</string>
     <string name="show_intelligent_suggestion_desc">当安装失败时显示智能建议</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -16,7 +16,7 @@
     <string name="menu">菜单</string>
     <string name="about">关于</string>
     <string name="other">其它</string>
-    <string name="about_detail">关于 InstallerX</string>
+    <string name="about_detail">关于 InstallerX Revived</string>
     <string name="get_update_detail">检查软件更新和新功能</string>
     <string name="internet_access_enabled">联网</string>
     <string name="internet_access_disabled">离线</string>
@@ -106,6 +106,10 @@
     <string name="config_install_mode_ignore">忽略</string>
     <string name="config_declare_installer">声明安装者（安装来源）</string>
     <string name="config_installer">安装者（包名）</string>
+    <string name="config_customize_user">设定用户</string>
+    <string name="config_customize_user_desc">手动设置为目标用户安装应用</string>
+    <string name="config_user_not_found">获取用户失败</string>
+    <string name="config_target_user">目标安装用户</string>
     <string name="config_manual_dexopt">手动 Dex 优化</string>
     <string name="config_manual_dexopt_desc">在安装后手动触发 dex2oat 进程</string>
     <string name="config_dexopt_mode">优化模式</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -314,7 +314,9 @@
     <string name="close_notification_immediately_on_dialog_dismiss">關閉對話框將靜默退出</string>
     <string name="set_countdown">設定倒數計時</string>
     <string name="dhizuku_auto_close_countdown_desc">Dhizuku安裝成功後自動關閉的倒數計時</string>
-    <string name="dhizuku_cannot_set_installer_desc">Dhizuku 模式下不支援設定安裝器</string>
+    <string name="dhizuku_cannot_set_installer_desc">Dhizuku 模式下不支援設定安裝器！</string>
+    <string name="dhizuku_cannot_set_user_desc">Dhizuku 模式不支援設定目標使用者！</string>
+    <string name="dhizuku_cannot_set_dexopt_desc">Dhizuku 模式不支援設定 dexopt！</string>
     <string name="grant_permission_after_install">點擊以在安裝完成後授予權限</string>
     <string name="show_intelligent_suggestion">顯示智能建議（實驗性）</string>
     <string name="show_intelligent_suggestion_desc">當安裝失敗時顯示智能建議</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -16,7 +16,7 @@
     <string name="menu">菜單</string>
     <string name="about">關於</string>
     <string name="other">其他</string>
-    <string name="about_detail">關於 InstallerX</string>
+    <string name="about_detail">關於 InstallerX Revived</string>
     <string name="get_update_detail">檢查軟體更新和新功能</string>
     <string name="stable">正式版</string>
     <string name="preview">預覽版</string>
@@ -102,6 +102,10 @@
     <string name="config_install_mode_ignore">忽略</string>
     <string name="config_declare_installer">聲明安裝者（安裝來源）</string>
     <string name="config_installer">安裝者（包名）</string>
+    <string name="config_customize_user">設定使用者帳號</string>
+    <string name="config_customize_user_desc">手動指定為目標使用者帳號安裝應用程式</string>
+    <string name="config_user_not_found">取得使用者帳號失敗</string>
+    <string name="config_target_user">目標安裝使用者帳號</string>
     <string name="config_auto_delete">自動刪除</string>
     <string name="config_auto_delete_dsp">安裝成功後自動刪除安裝包</string>
     <string name="config_display_sdk_version">顯示SDK資訊</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -81,6 +81,7 @@
     <string name="order">排序</string>
     <string name="config_name">名稱</string>
     <string name="config_info">資訊</string>
+    <string name="config_scope">作用域</string>
     <string name="config_description">描述</string>
     <string name="config_authorizer">授權器</string>
     <!--    <string name="config_authorizer_msg">用於執行解析與執行命令，請確保擁有足夠的權限。</string>-->
@@ -409,4 +410,5 @@
     <string name="suggestion_mi_isolation">臨時添加有效安裝者並重試</string>
     <string name="suggestion_user_restricted">前往開發者選項啟用USB安裝</string>
     <string name="suggestion_bypass_low_target_sdk">臨時允許繞過限制並重試</string>
+    <string name="suggestion_bypass_blacklist_set_by_user">本次允許安裝</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,6 +89,7 @@
     <string name="more">More</string>
     <string name="edit">Edit</string>
     <string name="apply">Apply</string>
+
     <string name="delete">Delete</string>
     <string name="restore">Undo</string>
 
@@ -101,6 +102,7 @@
 
     <string name="config_name">Profile name</string>
     <string name="config_info">Info</string>
+    <string name="config_scope">Scope</string>
     <string name="config_description">Profile description</string>
     <string name="config_authorizer">Authorizer</string>
     <string name="config_authorizer_global">Global</string>
@@ -463,4 +465,5 @@
     <string name="suggestion_mi_isolation">Temporarily add valid installer and retry</string>
     <string name="suggestion_user_restricted">Go to Developer options to enable USB installation</string>
     <string name="suggestion_bypass_low_target_sdk">Temporarily allow bypassing restrictions and retry</string>
+    <string name="suggestion_bypass_blacklist_set_by_user">Allow install once</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -364,6 +364,8 @@
     <string name="set_countdown">Set countdown</string>
     <string name="dhizuku_auto_close_countdown_desc">Countdown to auto-close after Dhizuku installation succeeds</string>
     <string name="dhizuku_cannot_set_installer_desc">Dhizuku mode does not support setting installer!</string>
+    <string name="dhizuku_cannot_set_user_desc">Dhizuku mode does not support setting target user!</string>
+    <string name="dhizuku_cannot_set_dexopt_desc">Dhizuku mode does not support setting dexopt!</string>
     <string name="grant_permission_after_install">Click to grant permission after installation</string>
     <string name="show_intelligent_suggestion">Show Intelligent Suggestions (Experimental)</string>
     <string name="show_intelligent_suggestion_desc">Show intelligent suggestions when installation fails</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,7 +20,7 @@
     <string name="menu">Menu</string>
     <string name="about">About</string>
     <string name="other">Other</string>
-    <string name="about_detail">About InstallerX</string>
+    <string name="about_detail">About InstallerX Revived</string>
     <string name="get_update">Get update</string>
     <string name="get_update_detail">Check for software updates and new features.</string>
 
@@ -121,6 +121,10 @@
     <string name="config_install_mode_ignore">Ignore</string>
     <string name="config_declare_installer">Set install source</string>
     <string name="config_installer">installed by (package name)</string>
+    <string name="config_customize_user">Set user to install</string>
+    <string name="config_customize_user_desc">Manually set the user you want to install app to</string>
+    <string name="config_user_not_found">User not found</string>
+    <string name="config_target_user">Target User</string>
     <string name="config_manual_dexopt">Manual Dex Optimization</string>
     <string name="config_manual_dexopt_desc">Manually trigger the dex2oat process after installation</string>
     <string name="config_dexopt_mode">Optimization Mode</string>


### PR DESCRIPTION
#### Summary

This pull request introduces a major feature: the ability to install applications for specific users on a multi-user Android device. It also includes several significant enhancements, such as a one-time blacklist bypass, UI improvements for authorizer-specific settings, and crucial fixes for the Shizuku service context.

#### Key Changes

**1. Multi-User Installation Support:**

* **Privileged Service & Backend:**
    * An `getUsers()` method has been added to the `IPrivilegedService` AIDL interface to retrieve a list of all device users.
    * The implementation in `DefaultPrivilegedService` uses reflection to access the system's hidden `IUserManager` API, securely fetching user IDs and names.
    * The feature is supported through the repository pattern (`PARepo`, `PARepoImpl`) to cleanly integrate with the application logic.

* **Database Migration:**
    * The Room database schema has been upgraded to version 7 to support the new feature.
    * The `ConfigEntity` table now includes `enable_customize_user` and `target_user_id` columns to store user selection preferences in profiles.

* **UI & ViewModel Integration:**
    * **Profile Settings:** A new "Set user to install" (`DataUserWidget`) switch has been added to the profile edit screen. When enabled, it reveals a dropdown menu populated with the list of available users fetched from the privileged service.
    * **Installation Dialog:** The extended installation menu now includes an option to select a target user for the current session, showing the selected user's name as a summary.
    * **ViewModel Logic:** `EditViewModel` and `DialogViewModel` have been updated to manage the state of available users, handle user selection, and pass the correct `targetUserId` to the installer backend.

**2. Bypass Blacklist on Install Failure:**

* When an installation fails due to the app being in the user-configured blacklist (`InstallFailedBlacklistedPackageException`), a new suggestion chip "Allow install once" now appears on the failure screen.
* Clicking this chip sets a temporary flag (`bypassBlacklistInstallSetByUser`) and immediately retries the installation, offering a convenient one-time override.

**3. Dhizuku Authorizer Enhancements:**

* To prevent confusion and unsupported operations, several settings are now dynamically disabled in the UI when Dhizuku is the effective authorizer. This includes:
    * Set install source
    * Set user to install
    * Manual Dex Optimization
* Informative descriptions are shown to the user explaining why these options are unavailable in Dhizuku mode.

**4. Shizuku Service Context Fix:**

* A new `createSystemContext` method has been implemented in `ShizukuUserServiceRecycler` to obtain a proper system-level context.
* This context is now used for Koin dependency injection, which should improve the stability and permission handling of the Shizuku user service.

**5. Minor UI & Localization Updates:**

* A new icon `AccountCircle` (`InstallUser`) has been added for the user selection feature.
* The application name in "About" pages has been updated to "InstallerX Revived" across multiple languages.
* Added new string resources for all new features and updated translations.

#### How to Test

1.  Navigate to **Settings -> Profile Management** and edit or create a new profile.
2.  Ensure the "Authorizer" is set to **Root** or **Shizuku**.
3.  Enable the **"Set user to install"** switch.
4.  A new dropdown for **"Target User"** should appear. Select a user other than the current one (e.g., a work profile user or another user account).
5.  Save the profile.
6.  Go back to the main screen and try to install an APK using the profile you just configured.
7.  Verify that the application is installed for the selected target user and not for the current user.