### PR TITLE
feat: support Android system installer as `None` installer

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,11 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission
         android:name="android.permission.QUERY_ALL_PACKAGES"
-        tools:ignore="QueryAllPackagesPermission" />
+        tools:ignore="PackageVisibilityPolicy,QueryAllPackagesPermission" />
+    <uses-permission
+        android:name="android.permission.REQUEST_INSTALL_PACKAGES"
+        tools:ignore="RequestInstallPackagesPolicy" />
+    <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />
 
     <uses-sdk tools:overrideLibrary="rikka.shizuku.api, rikka.shizuku.provider, rikka.shizuku.shared, rikka.shizuku.aidl" />
 

--- a/app/src/main/java/com/rosan/installer/data/app/model/exception/InstallFailedMissingInstallPermissionException.kt
+++ b/app/src/main/java/com/rosan/installer/data/app/model/exception/InstallFailedMissingInstallPermissionException.kt
@@ -1,0 +1,7 @@
+package com.rosan.installer.data.app.model.exception
+
+class InstallFailedMissingInstallPermissionException : Exception {
+    constructor() : super()
+
+    constructor(message: String?) : super(message)
+}

--- a/app/src/main/java/com/rosan/installer/data/app/model/impl/InstallerRepoImpl.kt
+++ b/app/src/main/java/com/rosan/installer/data/app/model/impl/InstallerRepoImpl.kt
@@ -3,6 +3,7 @@ package com.rosan.installer.data.app.model.impl
 import com.rosan.installer.data.app.model.entity.InstallEntity
 import com.rosan.installer.data.app.model.entity.InstallExtraInfoEntity
 import com.rosan.installer.data.app.model.impl.installer.DhizukuInstallerRepoImpl
+import com.rosan.installer.data.app.model.impl.installer.NoneInstallerRepoImpl
 import com.rosan.installer.data.app.model.impl.installer.ProcessInstallerRepoImpl
 import com.rosan.installer.data.app.model.impl.installer.ShizukuInstallerRepoImpl
 import com.rosan.installer.data.app.repo.InstallerRepo
@@ -20,6 +21,7 @@ object InstallerRepoImpl : InstallerRepo {
         val repo = when (config.authorizer) {
             ConfigEntity.Authorizer.Shizuku -> ShizukuInstallerRepoImpl
             ConfigEntity.Authorizer.Dhizuku -> DhizukuInstallerRepoImpl
+            ConfigEntity.Authorizer.None -> NoneInstallerRepoImpl
             else -> ProcessInstallerRepoImpl
         }
         repo.doInstallWork(config, entities, extra, blacklist, sharedUserIdBlacklist, sharedUserIdExemption)

--- a/app/src/main/java/com/rosan/installer/data/app/model/impl/installer/NoneInstallerRepoImpl.kt
+++ b/app/src/main/java/com/rosan/installer/data/app/model/impl/installer/NoneInstallerRepoImpl.kt
@@ -1,31 +1,140 @@
+// 文件: NoneInstallerRepoImpl.kt
 package com.rosan.installer.data.app.model.impl.installer
 
-import android.os.IBinder
-import com.rosan.app_process.AppProcess
-import com.rosan.app_process.NewProcessImpl
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageInstaller
+import android.provider.Settings
+import androidx.core.net.toUri
+import com.rosan.installer.data.app.model.entity.DataType
 import com.rosan.installer.data.app.model.entity.InstallEntity
 import com.rosan.installer.data.app.model.entity.InstallExtraInfoEntity
+import com.rosan.installer.data.app.model.exception.InstallFailedMissingInstallPermissionException
+import com.rosan.installer.data.app.repo.InstallerRepo
+import com.rosan.installer.data.app.util.PackageManagerUtil
+import com.rosan.installer.data.app.util.sourcePath
+import com.rosan.installer.data.recycle.util.deletePaths
 import com.rosan.installer.data.settings.model.room.entity.ConfigEntity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import timber.log.Timber
+import java.io.IOException
 
-object NoneInstallerRepoImpl : IBinderInstallerRepoImpl() {
-    private val newProcess = NewProcessImpl()
+object NoneInstallerRepoImpl : InstallerRepo, KoinComponent {
+    private val context by inject<Context>()
+    private val coroutineScope = CoroutineScope(Dispatchers.IO)
 
+    @SuppressLint("RequestInstallPackagesPolicy")
     override suspend fun doInstallWork(
-        config: ConfigEntity, entities: List<InstallEntity>, extra: InstallExtraInfoEntity, blacklist: List<String>,
+        config: ConfigEntity,
+        entities: List<InstallEntity>,
+        extra: InstallExtraInfoEntity,
+        blacklist: List<String>,
         sharedUserIdBlacklist: List<String>,
         sharedUserIdExemption: List<String>
     ) {
-        super.doInstallWork(config, entities, extra, blacklist, sharedUserIdBlacklist, sharedUserIdExemption)
+        val result = runCatching {
+            if (!context.packageManager.canRequestPackageInstalls()) {
+                val intent = Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES).apply {
+                    data = "package:${context.packageName}".toUri()
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                context.startActivity(intent)
+                throw InstallFailedMissingInstallPermissionException("Please make sure you have granted \"Install unknown apps\" permission!")
+            }
+
+            val packageInstaller = context.packageManager.packageInstaller
+            var session: PackageInstaller.Session? = null
+
+            try {
+                val params = PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL)
+                entities.firstOrNull()?.packageName?.let { params.setAppPackageName(it) }
+
+                val sessionId = packageInstaller.createSession(params)
+                session = packageInstaller.openSession(sessionId)
+
+                for (entity in entities) {
+                    session.openWrite(entity.name, 0, -1).use { outputStream ->
+                        entity.data.getInputStreamWhileNotEmpty()?.use { inputStream ->
+                            inputStream.copyTo(outputStream)
+                            session.fsync(outputStream)
+                        } ?: throw IOException("Failed to open input stream for ${entity.name}")
+                    }
+                }
+
+                val receiver = IBinderInstallerRepoImpl.LocalIntentReceiver()
+                session.commit(receiver.getIntentSender())
+
+                PackageManagerUtil.installResultVerify(context, receiver)
+
+            } catch (e: Exception) {
+                session?.abandon()
+                throw e
+            } finally {
+                session?.close()
+            }
+        }
+
+        doFinishWork(config, entities, extra, result)
+        // If the installation failed, re-throw the exception to notify the caller.
+        result.onFailure {
+            throw it
+        }
     }
 
-    override suspend fun iBinderWrapper(iBinder: IBinder): IBinder =
-        AppProcess.binderWrapper(newProcess, iBinder)
-
-    override suspend fun onDeleteWork(
+    private fun doFinishWork(
         config: ConfigEntity,
         entities: List<InstallEntity>,
+        extraInfo: InstallExtraInfoEntity,
+        result: Result<Unit>
+    ) {
+        Timber.tag("doFinishWork").d("isSuccess: ${result.isSuccess}")
+        if (result.isSuccess) {
+            // Enable autoDelete only when the containerType is not MULTI_APK_ZIP.
+            if (config.autoDelete && entities.first().containerType != DataType.MULTI_APK_ZIP) {
+                Timber.tag("doFinishWork").d("autoDelete is enabled, starting delete work.")
+                // Launch a background coroutine to handle file deletion.
+                coroutineScope.launch {
+                    // Use runCatching to prevent deletion errors from crashing the app.
+                    runCatching {
+                        onDeleteWork(entities)
+                    }.onFailure {
+                        Timber.e(it, "An error occurred during the onDeleteWork execution.")
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Handles the actual file deletion using standard, non-privileged APIs.
+     */
+    private fun onDeleteWork(
+        entities: List<InstallEntity>,
+    ) {
+        // Extract the source file paths from the install entities.
+        val pathsToDelete = entities.sourcePath()
+        if (pathsToDelete.isEmpty()) {
+            Timber.tag("onDeleteWork").w("No source paths found to delete.")
+            return
+        }
+
+        Timber.tag("onDeleteWork").d("Attempting to delete paths: ${pathsToDelete.joinToString()}")
+        // Use the robust deletePaths utility function which handles errors gracefully.
+        deletePaths(pathsToDelete)
+    }
+
+    override suspend fun doUninstallWork(
+        config: ConfigEntity,
+        packageName: String,
         extra: InstallExtraInfoEntity
     ) {
-        super.onDeleteWork(config, entities, extra)
     }
+
+    private fun List<InstallEntity>.sourcePath(): Array<String> =
+        this.mapNotNull { it.data.sourcePath() }.distinct().toTypedArray()
 }

--- a/app/src/main/java/com/rosan/installer/data/installer/model/impl/installer/ActionHandler.kt
+++ b/app/src/main/java/com/rosan/installer/data/installer/model/impl/installer/ActionHandler.kt
@@ -15,7 +15,6 @@ import android.provider.OpenableColumns
 import android.system.Os
 import androidx.core.net.toUri
 import com.rosan.installer.R
-import com.rosan.installer.build.Manufacturer
 import com.rosan.installer.build.RsConfig
 import com.rosan.installer.data.app.model.entity.AnalyseExtraEntity
 import com.rosan.installer.data.app.model.entity.AppEntity
@@ -249,10 +248,7 @@ class ActionHandler(scope: CoroutineScope, installer: InstallerRepo) :
             // Load the whitelist by UID from AppDataStore.
             Timber.d("[id=${installer.id}] install: Loading SharedUID whitelist from AppDataStore.")
             val sharedUserIdExemption = appDataStore
-                .getNamedPackageList(
-                    key = AppDataStore.MANAGED_SHARED_USER_ID_EXEMPTED_PACKAGES_LIST,
-                    default = if (RsConfig.currentManufacturer == Manufacturer.XIAOMI) AppDataStore.defaultSharedUidExemptedPackagesForXiaoMi else emptyList()
-                )
+                .getNamedPackageList(key = AppDataStore.MANAGED_SHARED_USER_ID_EXEMPTED_PACKAGES_LIST)
                 .first()
                 .map { it.packageName } // Extract the package names to compare
             Timber.d("[id=${installer.id}] install: SharedUID whitelist loaded with ${sharedUserIdExemption.size} entries.")

--- a/app/src/main/java/com/rosan/installer/data/settings/model/datastore/AppDataStore.kt
+++ b/app/src/main/java/com/rosan/installer/data/settings/model/datastore/AppDataStore.kt
@@ -68,16 +68,6 @@ class AppDataStore(
             stringPreferencesKey("managed_shared_user_id_blacklist")
         val MANAGED_SHARED_USER_ID_EXEMPTED_PACKAGES_LIST =
             stringPreferencesKey("managed_shared_user_id_blacklist_exempted_packages_list")
-
-        val defaultSharedUidBlacklist = listOf(
-            SharedUid(uidName = "android.uid.system", uidValue = 1000),
-            SharedUid(uidName = "android.uid.phone", uidValue = 1001)
-        )
-        val defaultSharedUidExemptedPackagesForXiaoMi = listOf(
-            NamedPackage(name = "安全服务", packageName = "com.miui.securitycenter"),
-            NamedPackage(name = "Joyose", packageName = "com.xiaomi.joyose"),
-            NamedPackage(name = "弹幕通知", packageName = "com.xiaomi.barrage")
-        )
     }
 
     suspend fun putString(key: Preferences.Key<String>, value: String) {
@@ -155,8 +145,11 @@ class AppDataStore(
      * @param key The Preferences.Key<String> to read from DataStore.
      * @return A Flow emitting the list of packages. Returns an empty list if no data or on error.
      */
-    fun getSharedUidList(key: Preferences.Key<String>): Flow<List<SharedUid>> =
-        getString(key, json.encodeToString(defaultSharedUidBlacklist)).map { jsonString ->
+    fun getSharedUidList(
+        key: Preferences.Key<String>,
+        default: List<SharedUid> = emptyList()
+    ): Flow<List<SharedUid>> =
+        getString(key, json.encodeToString(default)).map { jsonString ->
             try {
                 json.decodeFromString<List<SharedUid>>(jsonString)
             } catch (e: Exception) {

--- a/app/src/main/java/com/rosan/installer/ui/icons/AppIcons.kt
+++ b/app/src/main/java/com/rosan/installer/ui/icons/AppIcons.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.automirrored.twotone.MenuOpen
 import androidx.compose.material.icons.automirrored.twotone.Rule
 import androidx.compose.material.icons.automirrored.twotone.Send
 import androidx.compose.material.icons.automirrored.twotone.TrendingDown
+import androidx.compose.material.icons.filled.Lightbulb
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.outlined.DoNotDisturbOn
 import androidx.compose.material.icons.outlined.NotInterested
@@ -49,6 +50,7 @@ import androidx.compose.material.icons.twotone.LibraryAddCheck
 import androidx.compose.material.icons.twotone.Memory
 import androidx.compose.material.icons.twotone.People
 import androidx.compose.material.icons.twotone.PermDeviceInformation
+import androidx.compose.material.icons.twotone.Refresh
 import androidx.compose.material.icons.twotone.RocketLaunch
 import androidx.compose.material.icons.twotone.RoomPreferences
 import androidx.compose.material.icons.twotone.Save
@@ -73,12 +75,14 @@ object AppIcons {
     val Add = Icons.TwoTone.Add
     val Edit = Icons.TwoTone.Edit
     val Delete = Icons.TwoTone.Delete
+    val Retry = Icons.TwoTone.Refresh
     val Save = Icons.TwoTone.Save
     val BugReport = Icons.TwoTone.BugReport
     val Terminal = Icons.TwoTone.Terminal
     val Launcher = Icons.TwoTone.RocketLaunch
     val History = Icons.TwoTone.History
     val Suggestion = Icons.TwoTone.AutoAwesome
+    val Tip = Icons.Filled.Lightbulb
     val Update = Icons.TwoTone.SystemUpdate
     val Rule = Icons.AutoMirrored.TwoTone.Rule
     val Search = Icons.TwoTone.Search

--- a/app/src/main/java/com/rosan/installer/ui/page/main/installer/dialog/inner/InstallFailedDialog.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/installer/dialog/inner/InstallFailedDialog.kt
@@ -29,6 +29,7 @@ import com.rosan.installer.data.app.model.exception.InstallFailedBlacklistedPack
 import com.rosan.installer.data.app.model.exception.InstallFailedConflictingProviderException
 import com.rosan.installer.data.app.model.exception.InstallFailedDeprecatedSdkVersion
 import com.rosan.installer.data.app.model.exception.InstallFailedHyperOSIsolationViolationException
+import com.rosan.installer.data.app.model.exception.InstallFailedMissingInstallPermissionException
 import com.rosan.installer.data.app.model.exception.InstallFailedTestOnlyException
 import com.rosan.installer.data.app.model.exception.InstallFailedUpdateIncompatibleException
 import com.rosan.installer.data.app.model.exception.InstallFailedUserRestrictedException
@@ -244,6 +245,15 @@ private fun ErrorSuggestions(
                     },
                     labelRes = R.string.suggestion_bypass_blacklist_set_by_user,
                     icon = AppIcons.BugReport
+                )
+            )
+            add(
+                SuggestionChipInfo(
+                    InstallFailedMissingInstallPermissionException::class,
+                    selected = { true },
+                    onClick = { viewModel.dispatch(DialogViewAction.Install) },
+                    labelRes = R.string.retry,
+                    icon = AppIcons.Retry
                 )
             )
         }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/apply/ApplyPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/apply/ApplyPage.kt
@@ -94,7 +94,7 @@ import com.google.accompanist.drawablepainter.rememberDrawablePainter
 import com.rosan.installer.R
 import com.rosan.installer.ui.common.ViewContent
 import com.rosan.installer.ui.icons.AppIcons
-import com.rosan.installer.ui.page.main.widget.card.TipCard
+import com.rosan.installer.ui.page.main.widget.card.ScopeTipCard
 import com.rosan.installer.ui.page.main.widget.chip.Chip
 import com.rosan.installer.ui.page.main.widget.setting.AppBackButton
 import com.rosan.installer.ui.page.main.widget.setting.LabelWidget
@@ -254,7 +254,7 @@ fun ApplyPage(
                     ) {
                         Column(modifier = Modifier.fillMaxSize()) {
                             if (!viewModel.state.userReadScopeTips) {
-                                TipCard(viewModel = viewModel)
+                                ScopeTipCard(viewModel = viewModel)
                                 Spacer(modifier = Modifier.size(8.dp))
                             }
                             ItemsWidget(

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/apply/NewApplyPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/apply/NewApplyPage.kt
@@ -98,7 +98,7 @@ import com.google.accompanist.drawablepainter.rememberDrawablePainter
 import com.rosan.installer.R
 import com.rosan.installer.ui.common.ViewContent
 import com.rosan.installer.ui.icons.AppIcons
-import com.rosan.installer.ui.page.main.widget.card.TipCard
+import com.rosan.installer.ui.page.main.widget.card.ScopeTipCard
 import com.rosan.installer.ui.page.main.widget.chip.Chip
 import com.rosan.installer.ui.page.main.widget.setting.AppBackButton
 import com.rosan.installer.ui.page.main.widget.setting.LabelWidget
@@ -277,7 +277,7 @@ fun NewApplyPage(
                     ) {
                         Column(modifier = Modifier.fillMaxSize()) {
                             if (!viewModel.state.userReadScopeTips) {
-                                TipCard(viewModel = viewModel)
+                                ScopeTipCard(viewModel = viewModel)
                                 Spacer(modifier = Modifier.size(8.dp))
                             }
                             ItemsWidget(

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/edit/EditPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/edit/EditPage.kt
@@ -38,7 +38,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.rosan.installer.R
+import com.rosan.installer.data.settings.model.room.entity.ConfigEntity
 import com.rosan.installer.ui.icons.AppIcons
+import com.rosan.installer.ui.page.main.widget.card.NoneInstallerTipCard
 import com.rosan.installer.ui.page.main.widget.dialog.UnsavedChangesDialog
 import com.rosan.installer.ui.page.main.widget.setting.AppBackButton
 import com.rosan.installer.ui.page.main.widget.setting.DataAllowAllRequestedPermissionsWidget
@@ -84,6 +86,14 @@ fun EditPage(
     val snackBarHostState = remember { SnackbarHostState() }
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
     var showUnsavedDialog by remember { mutableStateOf(false) }
+
+    val stateAuthorizer = viewModel.state.data.authorizer
+    val globalAuthorizer = viewModel.globalAuthorizer
+    val isNone = when (stateAuthorizer) {
+        ConfigEntity.Authorizer.None -> true
+        ConfigEntity.Authorizer.Global -> globalAuthorizer == ConfigEntity.Authorizer.None
+        else -> false
+    }
 
     LaunchedEffect(listState) {
         var previousIndex = listState.firstVisibleItemIndex
@@ -216,22 +226,23 @@ fun EditPage(
             item { DataAuthorizerWidget(viewModel = viewModel) }
             item { DataCustomizeAuthorizerWidget(viewModel = viewModel) }
             item { DataInstallModeWidget(viewModel = viewModel) }
+            if (isNone) item { NoneInstallerTipCard() }
             item { LabelWidget(label = stringResource(R.string.config_label_installer_settings)) }
-            item { DataUserWidget(viewModel) }
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) item { DataPackageSourceWidget(viewModel) }
-            item { DataDeclareInstallerWidget(viewModel = viewModel) }
-            item { DataManualDexoptWidget(viewModel) }
-            item { DataAutoDeleteWidget(viewModel = viewModel) }
-            item { DisplaySdkWidget(viewModel = viewModel) }
+            item { DataUserWidget(viewModel = viewModel, isM3E = false) }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) item { DataPackageSourceWidget(viewModel, isM3E = false) }
+            item { DataDeclareInstallerWidget(viewModel = viewModel, isM3E = false) }
+            item { DataManualDexoptWidget(viewModel, isM3E = false) }
+            item { DataAutoDeleteWidget(viewModel = viewModel, isM3E = false) }
+            item { DisplaySdkWidget(viewModel = viewModel, isM3E = false) }
             item { LabelWidget(label = stringResource(R.string.config_label_install_options)) }
-            item { DataForAllUserWidget(viewModel = viewModel) }
-            item { DataAllowTestOnlyWidget(viewModel = viewModel) }
-            item { DataAllowDowngradeWidget(viewModel = viewModel) }
+            item { DataForAllUserWidget(viewModel = viewModel, isM3E = false) }
+            item { DataAllowTestOnlyWidget(viewModel = viewModel, isM3E = false) }
+            item { DataAllowDowngradeWidget(viewModel = viewModel, isM3E = false) }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
-                item { DataBypassLowTargetSdkWidget(viewModel = viewModel) }
+                item { DataBypassLowTargetSdkWidget(viewModel = viewModel, isM3E = false) }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
-                item { DataAllowRestrictedPermissionsWidget(viewModel = viewModel) }
-            item { DataAllowAllRequestedPermissionsWidget(viewModel = viewModel) }
+                item { DataAllowRestrictedPermissionsWidget(viewModel = viewModel, isM3E = false) }
+            item { DataAllowAllRequestedPermissionsWidget(viewModel = viewModel, isM3E = false) }
         }
     }
 }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/edit/NewEditPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/edit/NewEditPage.kt
@@ -48,7 +48,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.rosan.installer.R
+import com.rosan.installer.data.settings.model.room.entity.ConfigEntity
 import com.rosan.installer.ui.icons.AppIcons
+import com.rosan.installer.ui.page.main.widget.card.NoneInstallerTipCard
 import com.rosan.installer.ui.page.main.widget.dialog.UnsavedChangesDialog
 import com.rosan.installer.ui.page.main.widget.setting.AppBackButton
 import com.rosan.installer.ui.page.main.widget.setting.DataAllowAllRequestedPermissionsWidget
@@ -94,6 +96,15 @@ fun NewEditPage(
     val snackBarHostState = remember { SnackbarHostState() }
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
     var showUnsavedDialog by remember { mutableStateOf(false) }
+
+    val stateAuthorizer = viewModel.state.data.authorizer
+    val globalAuthorizer = viewModel.globalAuthorizer
+
+    val isNone = when (stateAuthorizer) {
+        ConfigEntity.Authorizer.None -> true
+        ConfigEntity.Authorizer.Global -> globalAuthorizer == ConfigEntity.Authorizer.None
+        else -> false
+    }
 
     LaunchedEffect(listState) {
         var previousIndex = listState.firstVisibleItemIndex
@@ -266,6 +277,8 @@ fun NewEditPage(
                     }
                 )
             }
+
+            if (isNone) item { NoneInstallerTipCard() }
 
             // --- Group 2: Installer Settings ---
             item {

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/NewPreferredPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/NewPreferredPage.kt
@@ -43,6 +43,7 @@ import com.rosan.installer.build.RsConfig
 import com.rosan.installer.data.settings.model.room.entity.ConfigEntity
 import com.rosan.installer.ui.icons.AppIcons
 import com.rosan.installer.ui.page.main.settings.SettingsScreen
+import com.rosan.installer.ui.page.main.widget.card.NoneInstallerTipCard
 import com.rosan.installer.ui.page.main.widget.dialog.ErrorDisplayDialog
 import com.rosan.installer.ui.page.main.widget.setting.BottomSheetContent
 import com.rosan.installer.ui.page.main.widget.setting.ClearCache
@@ -187,6 +188,8 @@ fun NewPreferredPage(
                             )
                         )
                     }
+
+                    if (viewModel.state.authorizer == ConfigEntity.Authorizer.None) item { NoneInstallerTipCard() }
 
                     // --- Basic Settings Group ---
                     item {

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/PreferredPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/PreferredPage.kt
@@ -186,6 +186,7 @@ fun PreferredPage(
                             checked = !state.adbVerifyEnabled,
                             isError = state.authorizer == ConfigEntity.Authorizer.Dhizuku,
                             enabled = state.authorizer != ConfigEntity.Authorizer.Dhizuku,
+                            isM3E = false,
                             onCheckedChange = { isDisabled ->
                                 viewModel.dispatch(
                                     PreferredViewAction.SetAdbVerifyEnabledState(!isDisabled)
@@ -197,6 +198,7 @@ fun PreferredPage(
                         IgnoreBatteryOptimizationSetting(
                             checked = state.isIgnoringBatteryOptimizations,
                             enabled = !state.isIgnoringBatteryOptimizations,
+                            isM3E = false,
                         ) { viewModel.dispatch(PreferredViewAction.RequestIgnoreBatteryOptimization) }
                     }
                     item { DefaultInstaller(true) { viewModel.dispatch(PreferredViewAction.SetDefaultInstaller(true)) } }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/PreferredViewModel.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/PreferredViewModel.kt
@@ -16,8 +16,6 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.rosan.installer.R
-import com.rosan.installer.build.Manufacturer
-import com.rosan.installer.build.RsConfig
 import com.rosan.installer.data.app.repo.PrivilegedActionRepo
 import com.rosan.installer.data.settings.model.datastore.AppDataStore
 import com.rosan.installer.data.settings.model.datastore.entity.NamedPackage
@@ -178,10 +176,7 @@ class PreferredViewModel(
             val managedSharedUserIdBlacklistFlow =
                 appDataStore.getSharedUidList(AppDataStore.MANAGED_SHARED_USER_ID_BLACKLIST)
             val managedSharedUserIdExemptPkgFlow =
-                appDataStore.getNamedPackageList(
-                    AppDataStore.MANAGED_SHARED_USER_ID_EXEMPTED_PACKAGES_LIST,
-                    if (RsConfig.currentManufacturer == Manufacturer.XIAOMI) AppDataStore.defaultSharedUidExemptedPackagesForXiaoMi else emptyList()
-                )
+                appDataStore.getNamedPackageList(AppDataStore.MANAGED_SHARED_USER_ID_EXEMPTED_PACKAGES_LIST)
 
             val adbVerifyEnabledFlow = getSettingsGlobalIntAsFlow(
                 context.contentResolver,

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/installer/LegacyInstallerGlobalSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/installer/LegacyInstallerGlobalSettingsPage.kt
@@ -111,6 +111,7 @@ fun LegacyInstallerGlobalSettingsPage(
                             title = stringResource(id = R.string.version_compare_in_single_line),
                             description = stringResource(id = R.string.version_compare_in_single_line_desc),
                             checked = state.versionCompareInSingleLine,
+                            isM3E = false,
                             onCheckedChange = {
                                 viewModel.dispatch(PreferredViewAction.ChangeVersionCompareInSingleLine(it))
                             }
@@ -120,6 +121,7 @@ fun LegacyInstallerGlobalSettingsPage(
                             title = stringResource(id = R.string.sdk_compare_in_multi_line),
                             description = stringResource(id = R.string.sdk_compare_in_multi_line_desc),
                             checked = state.sdkCompareInMultiLine,
+                            isM3E = false,
                             onCheckedChange = {
                                 viewModel.dispatch(PreferredViewAction.ChangeSdkCompareInMultiLine(it))
                             }
@@ -134,6 +136,7 @@ fun LegacyInstallerGlobalSettingsPage(
                                 title = stringResource(id = R.string.show_dialog_install_extended_menu),
                                 description = stringResource(id = R.string.show_dialog_install_extended_menu_desc),
                                 checked = viewModel.state.showDialogInstallExtendedMenu,
+                                isM3E = false,
                                 onCheckedChange = {
                                     viewModel.dispatch(
                                         PreferredViewAction.ChangeShowDialogInstallExtendedMenu(it)
@@ -146,6 +149,7 @@ fun LegacyInstallerGlobalSettingsPage(
                             title = stringResource(id = R.string.show_intelligent_suggestion),
                             description = stringResource(id = R.string.show_intelligent_suggestion_desc),
                             checked = viewModel.state.showSmartSuggestion,
+                            isM3E = false,
                             onCheckedChange = {
                                 viewModel.dispatch(
                                     PreferredViewAction.ChangeShowSuggestion(it)
@@ -157,6 +161,7 @@ fun LegacyInstallerGlobalSettingsPage(
                             title = stringResource(id = R.string.disable_notification),
                             description = stringResource(id = R.string.close_immediately_on_dialog_dismiss),
                             checked = viewModel.state.disableNotificationForDialogInstall,
+                            isM3E = false,
                             onCheckedChange = {
                                 viewModel.dispatch(
                                     PreferredViewAction.ChangeShowDisableNotification(it)
@@ -180,6 +185,7 @@ fun LegacyInstallerGlobalSettingsPage(
                             title = stringResource(id = R.string.show_dialog_when_pressing_notification),
                             description = stringResource(id = R.string.change_notification_touch_behavior),
                             checked = viewModel.state.showDialogWhenPressingNotification,
+                            isM3E = false,
                             onCheckedChange = {
                                 viewModel.dispatch(
                                     PreferredViewAction.ChangeShowDialogWhenPressingNotification(it)
@@ -196,6 +202,7 @@ fun LegacyInstallerGlobalSettingsPage(
                                 title = stringResource(id = R.string.disable_notification_on_dismiss),
                                 description = stringResource(id = R.string.close_notification_immediately_on_dialog_dismiss),
                                 checked = viewModel.state.disableNotificationForDialogInstall,
+                                isM3E = false,
                                 onCheckedChange = {
                                     viewModel.dispatch(
                                         PreferredViewAction.ChangeShowDisableNotification(it)

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/theme/LegacyThemeSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/theme/LegacyThemeSettingsPage.kt
@@ -68,7 +68,7 @@ fun LegacyThemeSettingsPage(
                 LabelWidget(label = stringResource(R.string.theme_settings_ui_style))
             }
             item {
-                Column(modifier = Modifier.padding(start = 36.dp, end = 12.dp)){
+                Column(modifier = Modifier.padding(start = 36.dp, end = 12.dp)) {
                     SelectableSettingItem(
                         title = stringResource(R.string.theme_settings_google_ui),
                         description = stringResource(R.string.theme_settings_google_ui_desc),
@@ -99,6 +99,7 @@ fun LegacyThemeSettingsPage(
                     title = stringResource(R.string.theme_settings_use_expressive_ui),
                     description = stringResource(R.string.theme_settings_use_expressive_ui_desc),
                     checked = state.showExpressiveUI,
+                    isM3E = false,
                     onCheckedChange = {
                         viewModel.dispatch(PreferredViewAction.ChangeShowExpressiveUI(it))
                     }
@@ -111,6 +112,7 @@ fun LegacyThemeSettingsPage(
                         title = stringResource(R.string.theme_settings_use_live_activity),
                         description = stringResource(R.string.theme_settings_use_live_activity_desc),
                         checked = state.showLiveActivity,
+                        isM3E = false,
                         onCheckedChange = {
                             viewModel.dispatch(
                                 PreferredViewAction.ChangeShowLiveActivity(it)
@@ -125,6 +127,7 @@ fun LegacyThemeSettingsPage(
                     title = stringResource(R.string.theme_settings_prefer_system_icon),
                     description = stringResource(R.string.theme_settings_prefer_system_icon_desc),
                     checked = state.preferSystemIcon,
+                    isM3E = false,
                     onCheckedChange = {
                         viewModel.dispatch(
                             PreferredViewAction.ChangePreferSystemIcon(it)
@@ -139,6 +142,7 @@ fun LegacyThemeSettingsPage(
                     title = stringResource(R.string.theme_settings_hide_launcher_icon),
                     description = stringResource(R.string.theme_settings_hide_launcher_icon_desc),
                     checked = !state.showLauncherIcon,
+                    isM3E = false,
                     onCheckedChange = { newCheckedState ->
                         if (newCheckedState) {
                             showHideLauncherIconDialog = true

--- a/app/src/main/java/com/rosan/installer/ui/page/main/widget/card/TipCard.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/widget/card/TipCard.kt
@@ -2,12 +2,13 @@ package com.rosan.installer.ui.page.main.widget.card
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Lightbulb
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -22,14 +23,28 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.rosan.installer.R
+import com.rosan.installer.ui.icons.AppIcons
 import com.rosan.installer.ui.page.main.settings.config.apply.ApplyViewAction
 import com.rosan.installer.ui.page.main.settings.config.apply.ApplyViewModel
 
+/**
+ * A general-purpose card for displaying tips or important information.
+ *
+ * @param modifier The modifier to be applied to the card.
+ * @param tipContent The composable slot for the main tip message.
+ * This is typically a Row with an Icon and Text.
+ * @param actionContent The composable slot for action buttons, typically aligned to the end.
+ * It's within a ColumnScope, so modifiers like `align` are allowed.
+ */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-fun TipCard(viewModel: ApplyViewModel) {
+fun TipCard(
+    modifier: Modifier = Modifier,
+    tipContent: @Composable () -> Unit,
+    actionContent: @Composable ColumnScope.() -> Unit
+) {
     Card(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 8.dp),
         colors = CardDefaults.cardColors(
@@ -40,12 +55,28 @@ fun TipCard(viewModel: ApplyViewModel) {
         Column(
             modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp)
         ) {
+            // Slot for the tip content
+            tipContent()
+
+            // Slot for the action content (e.g., a button)
+            // The ColumnScope is provided to this lambda,
+            // so consumers can use `Modifier.align(Alignment.End)`.
+            actionContent()
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun ScopeTipCard(viewModel: ApplyViewModel) {
+    TipCard(
+        tipContent = {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 Icon(
-                    imageVector = Icons.Filled.Lightbulb,
+                    imageVector = AppIcons.Tip,
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.onTertiary
                 )
@@ -55,16 +86,42 @@ fun TipCard(viewModel: ApplyViewModel) {
                     color = MaterialTheme.colorScheme.onTertiary
                 )
             }
-            // TextButton aligned to the end (right) of the Column
-            TextButton(
-                onClick = { viewModel.dispatch(ApplyViewAction.UserReadScopeTips) },
-                modifier = Modifier.align(Alignment.End),
-                colors = ButtonDefaults.textButtonColors(
-                    contentColor = MaterialTheme.colorScheme.onPrimary
-                )
+        }
+    ) {
+        TextButton(
+            onClick = { viewModel.dispatch(ApplyViewAction.UserReadScopeTips) },
+            modifier = Modifier.align(Alignment.End),
+            colors = ButtonDefaults.textButtonColors(
+                contentColor = MaterialTheme.colorScheme.onTertiary
+            )
+        ) {
+            Text(stringResource(R.string.got_it))
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun NoneInstallerTipCard() {
+    TipCard(
+        tipContent = {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Text(stringResource(R.string.got_it))
+                Icon(
+                    imageVector = AppIcons.Tip,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onTertiary
+                )
+                Text(
+                    text = stringResource(R.string.config_authorizer_none_tips),
+                    style = MaterialTheme.typography.bodyMediumEmphasized,
+                    color = MaterialTheme.colorScheme.onTertiary
+                )
             }
         }
+    ) {
+        Spacer(modifier = Modifier.size(16.dp))
     }
 }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/widget/setting/EditItemWidget.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/widget/setting/EditItemWidget.kt
@@ -37,6 +37,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.rosan.installer.R
+import com.rosan.installer.build.Manufacturer
+import com.rosan.installer.build.RsConfig
 import com.rosan.installer.data.settings.model.room.entity.ConfigEntity
 import com.rosan.installer.ui.icons.AppIcons
 import com.rosan.installer.ui.page.main.settings.config.edit.EditViewAction
@@ -92,24 +94,27 @@ fun DataDescriptionWidget(viewModel: EditViewModel) {
 fun DataAuthorizerWidget(viewModel: EditViewModel) {
     val stateAuthorizer = viewModel.state.data.authorizer
     val globalAuthorizer = viewModel.globalAuthorizer
-    val data = mapOf(
-        ConfigEntity.Authorizer.Global to stringResource(
-            R.string.config_authorizer_global_desc,
-            when (globalAuthorizer) {
-                // ConfigEntity.Authorizer.None -> stringResource(R.string.config_authorizer_none)
-                ConfigEntity.Authorizer.Root -> stringResource(R.string.config_authorizer_root)
-                ConfigEntity.Authorizer.Shizuku -> stringResource(R.string.config_authorizer_shizuku)
-                ConfigEntity.Authorizer.Dhizuku -> stringResource(R.string.config_authorizer_dhizuku)
-                ConfigEntity.Authorizer.Customize -> stringResource(R.string.config_authorizer_customize)
-                else -> stringResource(R.string.config_authorizer_global)
-            }
-        ),
-        // ConfigEntity.Authorizer.None to stringResource(R.string.config_authorizer_none),
-        ConfigEntity.Authorizer.Root to stringResource(R.string.config_authorizer_root),
-        ConfigEntity.Authorizer.Shizuku to stringResource(R.string.config_authorizer_shizuku),
-        ConfigEntity.Authorizer.Dhizuku to stringResource(R.string.config_authorizer_dhizuku),
-        ConfigEntity.Authorizer.Customize to stringResource(R.string.config_authorizer_customize)
-    )
+    val data = buildMap {
+        put(
+            ConfigEntity.Authorizer.Global, stringResource(
+                R.string.config_authorizer_global_desc,
+                when (globalAuthorizer) {
+                    ConfigEntity.Authorizer.None -> stringResource(R.string.config_authorizer_none)
+                    ConfigEntity.Authorizer.Root -> stringResource(R.string.config_authorizer_root)
+                    ConfigEntity.Authorizer.Shizuku -> stringResource(R.string.config_authorizer_shizuku)
+                    ConfigEntity.Authorizer.Dhizuku -> stringResource(R.string.config_authorizer_dhizuku)
+                    ConfigEntity.Authorizer.Customize -> stringResource(R.string.config_authorizer_customize)
+                    else -> stringResource(R.string.config_authorizer_global)
+                }
+            )
+        )
+        if (RsConfig.currentManufacturer != Manufacturer.XIAOMI)
+            put(ConfigEntity.Authorizer.None, stringResource(R.string.config_authorizer_none))
+        put(ConfigEntity.Authorizer.Root, stringResource(R.string.config_authorizer_root))
+        put(ConfigEntity.Authorizer.Shizuku, stringResource(R.string.config_authorizer_shizuku))
+        put(ConfigEntity.Authorizer.Dhizuku, stringResource(R.string.config_authorizer_dhizuku))
+        put(ConfigEntity.Authorizer.Customize, stringResource(R.string.config_authorizer_customize))
+    }
     DropDownMenuWidget(
         icon = Icons.TwoTone.Memory,
         title = stringResource(R.string.config_authorizer),
@@ -181,7 +186,7 @@ fun DataInstallModeWidget(viewModel: EditViewModel) {
 }
 
 @Composable
-fun DataPackageSourceWidget(viewModel: EditViewModel) {
+fun DataPackageSourceWidget(viewModel: EditViewModel, isM3E: Boolean = true) {
     val stateAuthorizer = viewModel.state.data.authorizer
     val globalAuthorizer = viewModel.globalAuthorizer
     val enableCustomizePackageSource = viewModel.state.data.enableCustomizePackageSource
@@ -207,6 +212,7 @@ fun DataPackageSourceWidget(viewModel: EditViewModel) {
             checked = enableCustomizePackageSource,
             enabled = !isDhizuku,
             isError = isDhizuku,
+            isM3E = isM3E,
             onCheckedChange = {
                 viewModel.dispatch(EditViewAction.ChangeDataEnableCustomizePackageSource(it))
             }
@@ -242,7 +248,7 @@ fun DataPackageSourceWidget(viewModel: EditViewModel) {
 }
 
 @Composable
-fun DataDeclareInstallerWidget(viewModel: EditViewModel) {
+fun DataDeclareInstallerWidget(viewModel: EditViewModel, isM3E: Boolean = true) {
     val stateAuthorizer = viewModel.state.data.authorizer
     val globalAuthorizer = viewModel.globalAuthorizer
 
@@ -263,11 +269,8 @@ fun DataDeclareInstallerWidget(viewModel: EditViewModel) {
         icon = AppIcons.InstallSource,
         title = stringResource(id = R.string.config_declare_installer),
         checked = viewModel.state.data.declareInstaller,
-        onCheckedChange = {
-            // 这是该组件唯一允许的 dispatch，即响应用户的直接交互
-            viewModel.dispatch(EditViewAction.ChangeDataDeclareInstaller(it))
-        },
-        // 将从 ViewModel 获取的状态直接传递给下一层
+        onCheckedChange = { viewModel.dispatch(EditViewAction.ChangeDataDeclareInstaller(it)) },
+        isM3E = isM3E,
         description = description,
         enabled = !isDhizuku,
         isError = isDhizuku
@@ -366,7 +369,7 @@ fun DataInstallerWidget(viewModel: EditViewModel) {
 }
 
 @Composable
-fun DataUserWidget(viewModel: EditViewModel) {
+fun DataUserWidget(viewModel: EditViewModel, isM3E: Boolean = true) {
     val stateAuthorizer = viewModel.state.data.authorizer
     val globalAuthorizer = viewModel.globalAuthorizer
     val enableCustomizeUser = viewModel.state.data.enableCustomizeUser
@@ -391,6 +394,7 @@ fun DataUserWidget(viewModel: EditViewModel) {
             checked = enableCustomizeUser,
             enabled = !isDhizuku,
             isError = isDhizuku,
+            isM3E = isM3E,
             onCheckedChange = {
                 viewModel.dispatch(EditViewAction.ChangeDataCustomizeUser(it))
             }
@@ -417,7 +421,7 @@ fun DataUserWidget(viewModel: EditViewModel) {
 }
 
 @Composable
-fun DataManualDexoptWidget(viewModel: EditViewModel) {
+fun DataManualDexoptWidget(viewModel: EditViewModel, isM3E: Boolean = true) {
     val stateAuthorizer = viewModel.state.data.authorizer
     val globalAuthorizer = viewModel.globalAuthorizer
 
@@ -438,6 +442,7 @@ fun DataManualDexoptWidget(viewModel: EditViewModel) {
         checked = viewModel.state.data.enableManualDexopt,
         enabled = !isDhizuku,
         isError = isDhizuku,
+        isM3E = isM3E,
         onCheckedChange = {
             viewModel.dispatch(EditViewAction.ChangeDataEnableManualDexopt(it))
         }
@@ -461,6 +466,7 @@ fun DataManualDexoptWidget(viewModel: EditViewModel) {
                 title = stringResource(id = R.string.config_force_dexopt),
                 description = stringResource(id = R.string.config_force_dexopt_desc),
                 checked = viewModel.state.data.forceDexopt,
+                isM3E = isM3E,
                 onCheckedChange = {
                     viewModel.dispatch(EditViewAction.ChangeDataForceDexopt(it))
                 }
@@ -480,57 +486,55 @@ fun DataManualDexoptWidget(viewModel: EditViewModel) {
 }
 
 @Composable
-fun DataAutoDeleteWidget(viewModel: EditViewModel) {
+fun DataAutoDeleteWidget(viewModel: EditViewModel, isM3E: Boolean = true) {
     SwitchWidget(
         icon = AppIcons.Delete,
         title = stringResource(id = R.string.config_auto_delete),
         description = stringResource(id = R.string.config_auto_delete_dsp),
         checked = viewModel.state.data.autoDelete,
-        onCheckedChange = {
-            viewModel.dispatch(EditViewAction.ChangeDataAutoDelete(it))
-        }
+        isM3E = isM3E,
+        onCheckedChange = { viewModel.dispatch(EditViewAction.ChangeDataAutoDelete(it)) }
     )
 }
 
 @Composable
-fun DisplaySdkWidget(viewModel: EditViewModel) {
+fun DisplaySdkWidget(viewModel: EditViewModel, isM3E: Boolean = true) {
     SwitchWidget(
         icon = AppIcons.Info,
         title = stringResource(id = R.string.config_display_sdk_version),
         description = stringResource(id = R.string.config_display_sdk_version_sdp),
         checked = viewModel.state.data.displaySdk,
-        onCheckedChange = {
-            viewModel.dispatch(EditViewAction.ChangeDisplaySdk(it))
-        }
+        isM3E = isM3E,
+        onCheckedChange = { viewModel.dispatch(EditViewAction.ChangeDisplaySdk(it)) }
     )
 }
 
 @Composable
-fun DataForAllUserWidget(viewModel: EditViewModel) {
+fun DataForAllUserWidget(viewModel: EditViewModel, isM3E: Boolean = true) {
     SwitchWidget(
         icon = AppIcons.InstallForAllUsers,
         title = stringResource(id = R.string.config_all_users),
         description = stringResource(id = R.string.config_all_users_desc),
         checked = viewModel.state.data.forAllUser,
+        isM3E = isM3E,
         onCheckedChange = { viewModel.dispatch(EditViewAction.ChangeDataForAllUser(it)) }
     )
 }
 
 @Composable
-fun DataAllowTestOnlyWidget(viewModel: EditViewModel) {
+fun DataAllowTestOnlyWidget(viewModel: EditViewModel, isM3E: Boolean = true) {
     SwitchWidget(
         icon = AppIcons.BugReport,
         title = stringResource(id = R.string.config_allow_test),
         description = stringResource(id = R.string.config_allow_test_desc),
         checked = viewModel.state.data.allowTestOnly,
-        onCheckedChange = {
-            viewModel.dispatch(EditViewAction.ChangeDataAllowTestOnly(it))
-        }
+        isM3E = isM3E,
+        onCheckedChange = { viewModel.dispatch(EditViewAction.ChangeDataAllowTestOnly(it)) }
     )
 }
 
 @Composable
-fun DataAllowDowngradeWidget(viewModel: EditViewModel) {
+fun DataAllowDowngradeWidget(viewModel: EditViewModel, isM3E: Boolean = true) {
     val stateAuthorizer = viewModel.state.data.authorizer
     val globalAuthorizer = viewModel.globalAuthorizer
 
@@ -552,41 +556,43 @@ fun DataAllowDowngradeWidget(viewModel: EditViewModel) {
         checked = viewModel.state.data.allowDowngrade,
         enabled = !isBlocked,
         isError = isBlocked,
-        onCheckedChange = {
-            viewModel.dispatch(EditViewAction.ChangeDataAllowDowngrade(it))
-        }
+        isM3E = isM3E,
+        onCheckedChange = { viewModel.dispatch(EditViewAction.ChangeDataAllowDowngrade(it)) }
     )
 }
 
 @Composable
-fun DataBypassLowTargetSdkWidget(viewModel: EditViewModel) {
+fun DataBypassLowTargetSdkWidget(viewModel: EditViewModel, isM3E: Boolean = true) {
     SwitchWidget(
         icon = AppIcons.InstallBypassLowTargetSdk,
         title = stringResource(id = R.string.config_bypass_low_target_sdk),
         description = stringResource(id = R.string.config_bypass_low_target_sdk_desc),
         checked = viewModel.state.data.bypassLowTargetSdk,
+        isM3E = isM3E,
         onCheckedChange = { viewModel.dispatch(EditViewAction.ChangeDataBypassLowTargetSdk(it)) }
     )
 }
 
 @Composable
-fun DataAllowRestrictedPermissionsWidget(viewModel: EditViewModel) {
+fun DataAllowRestrictedPermissionsWidget(viewModel: EditViewModel, isM3E: Boolean = true) {
     SwitchWidget(
         icon = AppIcons.InstallAllowRestrictedPermissions,
         title = stringResource(id = R.string.config_all_whitelist_restricted_permissions),
         description = stringResource(id = R.string.config_all_whitelist_restricted_permissions_desc),
         checked = viewModel.state.data.allowRestrictedPermissions,
+        isM3E = isM3E,
         onCheckedChange = { viewModel.dispatch(EditViewAction.ChangeDataAllowRestrictedPermissions(it)) }
     )
 }
 
 @Composable
-fun DataAllowAllRequestedPermissionsWidget(viewModel: EditViewModel) {
+fun DataAllowAllRequestedPermissionsWidget(viewModel: EditViewModel, isM3E: Boolean = true) {
     SwitchWidget(
         icon = AppIcons.InstallAllowAllRequestedPermissions,
         title = stringResource(id = R.string.config_grant_all_permissions),
         description = stringResource(id = R.string.config_grant_all_permissions_desc),
         checked = viewModel.state.data.allowAllRequestedPermissions,
+        isM3E = isM3E,
         onCheckedChange = { viewModel.dispatch(EditViewAction.ChangeDataAllowAllRequestedPermissions(it)) }
     )
 }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/widget/setting/SettingsItemWidget.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/widget/setting/SettingsItemWidget.kt
@@ -62,6 +62,8 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.rosan.installer.R
+import com.rosan.installer.build.Manufacturer
+import com.rosan.installer.build.RsConfig
 import com.rosan.installer.data.settings.model.datastore.entity.NamedPackage
 import com.rosan.installer.data.settings.model.datastore.entity.SharedUid
 import com.rosan.installer.data.settings.model.room.entity.ConfigEntity
@@ -168,7 +170,10 @@ fun DataAuthorizerWidget(
                 // 遍历 Map 来动态创建 InputChip
                 authorizerOptions.forEach { (authorizerType, authorizerInfo) ->
                     InputChip(
-                        enabled = authorizerType != ConfigEntity.Authorizer.None,
+                        enabled = when (authorizerType) {
+                            ConfigEntity.Authorizer.None -> RsConfig.currentManufacturer != Manufacturer.XIAOMI
+                            else -> true
+                        },
                         selected = currentAuthorizer == authorizerType,
                         onClick = {
                             haptic.performHapticFeedback(HapticFeedbackType.ContextClick)
@@ -332,6 +337,7 @@ fun DisableAdbVerify(
     checked: Boolean,
     isError: Boolean,
     enabled: Boolean,
+    isM3E: Boolean = true,
     onCheckedChange: (Boolean) -> Unit
 ) {
     SwitchWidget(
@@ -342,6 +348,7 @@ fun DisableAdbVerify(
         isError = isError,
         checked = checked,
         enabled = enabled,
+        isM3E = isM3E,
         onCheckedChange = onCheckedChange
     )
 }
@@ -356,6 +363,7 @@ fun DisableAdbVerify(
 fun IgnoreBatteryOptimizationSetting(
     checked: Boolean,
     enabled: Boolean,
+    isM3E: Boolean = true,
     onCheckedChange: (Boolean) -> Unit
 ) {
     SwitchWidget(
@@ -365,6 +373,7 @@ fun IgnoreBatteryOptimizationSetting(
         else stringResource(R.string.ignore_battery_optimizations_desc_disabled),
         checked = checked,
         enabled = enabled,
+        isM3E = isM3E,
         onCheckedChange = onCheckedChange
     )
 }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/widget/setting/SwitchWidget.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/widget/setting/SwitchWidget.kt
@@ -1,12 +1,72 @@
 package com.rosan.installer.ui.page.main.widget.setting
 
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 
 @Composable
 fun SwitchWidget(
+    icon: ImageVector? = null,
+    title: String,
+    description: String? = null,
+    enabled: Boolean = true,
+    checked: Boolean,
+    isM3E: Boolean = true,
+    onCheckedChange: (Boolean) -> Unit,
+    isError: Boolean = false
+) {
+    val toggleAction = {
+        if (enabled) {
+            onCheckedChange(!checked)
+        }
+    }
+
+    BaseWidget(
+        icon = icon,
+        title = title,
+        enabled = enabled,
+        isError = isError,
+        onClick = toggleAction,
+        hapticFeedbackType = HapticFeedbackType.ToggleOn,
+        description = description
+    ) {
+        Switch(
+            enabled = enabled,
+            checked = checked,
+            thumbContent = if (isM3E && checked) {
+                {
+                    Icon(
+                        imageVector = Icons.Filled.Check,
+                        contentDescription = null,
+                        modifier = Modifier.size(SwitchDefaults.IconSize),
+                    )
+                }
+            } else if (isM3E) {
+                {
+                    Icon(
+                        imageVector = Icons.Filled.Close,
+                        contentDescription = null,
+                        modifier = Modifier.size(SwitchDefaults.IconSize),
+                    )
+                }
+            } else {
+                null
+            },
+            onCheckedChange = null
+        )
+    }
+}
+
+@Composable
+fun M3ESwitchWidget(
     icon: ImageVector? = null,
     title: String,
     description: String? = null,
@@ -33,6 +93,17 @@ fun SwitchWidget(
         Switch(
             enabled = enabled,
             checked = checked,
+            thumbContent = if (checked) {
+                {
+                    Icon(
+                        imageVector = Icons.Filled.Check,
+                        contentDescription = null,
+                        modifier = Modifier.size(SwitchDefaults.IconSize),
+                    )
+                }
+            } else {
+                null
+            },
             onCheckedChange = null
         )
     }

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/widgets/MiuixEditItemWidget.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/widgets/MiuixEditItemWidget.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.rosan.installer.R
+import com.rosan.installer.build.Manufacturer
+import com.rosan.installer.build.RsConfig
 import com.rosan.installer.data.settings.model.room.entity.ConfigEntity
 import com.rosan.installer.ui.icons.AppIcons
 import com.rosan.installer.ui.page.main.settings.config.edit.EditViewAction
@@ -68,24 +70,27 @@ fun MiuixDataDescriptionWidget(viewModel: EditViewModel) {
 fun MiuixDataAuthorizerWidget(viewModel: EditViewModel) {
     val stateAuthorizer = viewModel.state.data.authorizer
     val globalAuthorizer = viewModel.globalAuthorizer
-    val data = mapOf(
-        ConfigEntity.Authorizer.Global to stringResource(
-            R.string.config_authorizer_global_desc,
-            when (globalAuthorizer) {
-                // ConfigEntity.Authorizer.None -> stringResource(R.string.config_authorizer_none)
-                ConfigEntity.Authorizer.Root -> stringResource(R.string.config_authorizer_root)
-                ConfigEntity.Authorizer.Shizuku -> stringResource(R.string.config_authorizer_shizuku)
-                ConfigEntity.Authorizer.Dhizuku -> stringResource(R.string.config_authorizer_dhizuku)
-                ConfigEntity.Authorizer.Customize -> stringResource(R.string.config_authorizer_customize)
-                else -> stringResource(R.string.config_authorizer_global)
-            }
-        ),
-        // ConfigEntity.Authorizer.None to stringResource(R.string.config_authorizer_none),
-        ConfigEntity.Authorizer.Root to stringResource(R.string.config_authorizer_root),
-        ConfigEntity.Authorizer.Shizuku to stringResource(R.string.config_authorizer_shizuku),
-        ConfigEntity.Authorizer.Dhizuku to stringResource(R.string.config_authorizer_dhizuku),
-        ConfigEntity.Authorizer.Customize to stringResource(R.string.config_authorizer_customize)
-    )
+    val data = buildMap {
+        put(
+            ConfigEntity.Authorizer.Global, stringResource(
+                R.string.config_authorizer_global_desc,
+                when (globalAuthorizer) {
+                    ConfigEntity.Authorizer.None -> stringResource(R.string.config_authorizer_none)
+                    ConfigEntity.Authorizer.Root -> stringResource(R.string.config_authorizer_root)
+                    ConfigEntity.Authorizer.Shizuku -> stringResource(R.string.config_authorizer_shizuku)
+                    ConfigEntity.Authorizer.Dhizuku -> stringResource(R.string.config_authorizer_dhizuku)
+                    ConfigEntity.Authorizer.Customize -> stringResource(R.string.config_authorizer_customize)
+                    else -> stringResource(R.string.config_authorizer_global)
+                }
+            )
+        )
+        if (RsConfig.currentManufacturer != Manufacturer.XIAOMI)
+            put(ConfigEntity.Authorizer.None, stringResource(R.string.config_authorizer_none))
+        put(ConfigEntity.Authorizer.Root, stringResource(R.string.config_authorizer_root))
+        put(ConfigEntity.Authorizer.Shizuku, stringResource(R.string.config_authorizer_shizuku))
+        put(ConfigEntity.Authorizer.Dhizuku, stringResource(R.string.config_authorizer_dhizuku))
+        put(ConfigEntity.Authorizer.Customize, stringResource(R.string.config_authorizer_customize))
+    }
     // Convert data Map to List<SpinnerEntry> required by SuperSpinner.
     val spinnerEntries = remember(data) {
         data.values.map { authorizerName ->

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/widgets/MiuixSettingsItemWidget.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/widgets/MiuixSettingsItemWidget.kt
@@ -53,6 +53,8 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.rosan.installer.R
+import com.rosan.installer.build.Manufacturer
+import com.rosan.installer.build.RsConfig
 import com.rosan.installer.data.settings.model.datastore.entity.NamedPackage
 import com.rosan.installer.data.settings.model.datastore.entity.SharedUid
 import com.rosan.installer.data.settings.model.room.entity.ConfigEntity
@@ -93,24 +95,25 @@ fun MiuixDataAuthorizerWidget(
 
     // The data source remains unchanged.
     val authorizerOptions = remember {
-        mapOf(
-            /*ConfigEntity.Authorizer.None to AuthorizerInfo(
-                R.string.config_authorizer_none,
-                AppIcons.None
-            ),*/
-            ConfigEntity.Authorizer.Root to AuthorizerInfo(
-                R.string.config_authorizer_root,
-                AppIcons.Root
-            ),
-            ConfigEntity.Authorizer.Shizuku to AuthorizerInfo(
-                R.string.config_authorizer_shizuku,
-                shizukuIcon
-            ),
-            ConfigEntity.Authorizer.Dhizuku to AuthorizerInfo(
-                R.string.config_authorizer_dhizuku,
-                AppIcons.InstallAllowRestrictedPermissions
-            ),
-        )
+        buildMap {
+            if (RsConfig.currentManufacturer != Manufacturer.XIAOMI)
+                put(
+                    ConfigEntity.Authorizer.None,
+                    AuthorizerInfo(R.string.config_authorizer_none, AppIcons.None)
+                )
+            put(
+                ConfigEntity.Authorizer.Root,
+                AuthorizerInfo(R.string.config_authorizer_root, AppIcons.Root)
+            )
+            put(
+                ConfigEntity.Authorizer.Shizuku,
+                AuthorizerInfo(R.string.config_authorizer_shizuku, shizukuIcon)
+            )
+            put(
+                ConfigEntity.Authorizer.Dhizuku,
+                AuthorizerInfo(R.string.config_authorizer_dhizuku, AppIcons.InstallAllowRestrictedPermissions)
+            )
+        }
     }
 
     //    Convert the authorizerOptions Map into a List<SpinnerEntry>

--- a/app/src/main/java/com/rosan/installer/util/ThrowableUtil.kt
+++ b/app/src/main/java/com/rosan/installer/util/ThrowableUtil.kt
@@ -22,6 +22,7 @@ import com.rosan.installer.data.app.model.exception.InstallFailedInvalidInstallL
 import com.rosan.installer.data.app.model.exception.InstallFailedInvalidURIException
 import com.rosan.installer.data.app.model.exception.InstallFailedMediaUnavailableException
 import com.rosan.installer.data.app.model.exception.InstallFailedMissingFeatureException
+import com.rosan.installer.data.app.model.exception.InstallFailedMissingInstallPermissionException
 import com.rosan.installer.data.app.model.exception.InstallFailedMissingSharedLibraryException
 import com.rosan.installer.data.app.model.exception.InstallFailedNewerSDKException
 import com.rosan.installer.data.app.model.exception.InstallFailedNoSharedUserException
@@ -71,6 +72,7 @@ private fun Throwable.getStringResourceId() =
         is InstallFailedUpdateIncompatibleException -> R.string.exception_install_failed_update_incompatible
         is InstallFailedSharedUserIncompatibleException -> R.string.exception_install_failed_shared_user_incompatible
         is InstallFailedMissingSharedLibraryException -> R.string.exception_install_failed_missing_shared_library
+        is InstallFailedMissingInstallPermissionException -> R.string.exception_install_failed_missing_install_permission
         is InstallFailedReplaceCouldntDeleteException -> R.string.exception_install_failed_replace_couldnt_delete
         is InstallFailedDexOptException -> R.string.exception_install_failed_dexopt
         is InstallFailedOlderSdkException -> R.string.exception_install_failed_older_sdk

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -102,6 +102,7 @@
     <string name="config_authorizer_global">跟随全局</string>
     <string name="config_authorizer_global_desc">跟随全局（%1$s）</string>
     <string name="config_authorizer_none">无</string>
+    <string name="config_authorizer_none_tips">使用系统安装器时，此处的大多数选项将无效。</string>
     <string name="config_authorizer_root">ROOT超级用户</string>
     <string name="config_authorizer_shizuku">Shizuku</string>
     <string name="config_authorizer_dhizuku">Dhizuku</string>
@@ -314,6 +315,7 @@
     <string name="exception_install_failed_update_incompatible">更新失败（签名或其他原因），请卸载后安装</string>
     <string name="exception_install_failed_shared_user_incompatible">与共享UID的程序签名冲突</string>
     <string name="exception_install_failed_missing_shared_library">缺失共享库</string>
+    <string name="exception_install_failed_missing_install_permission">请授予未知安装来源权限然后重试</string>
     <string name="exception_install_failed_replace_couldnt_delete">无效的共享库</string>
     <string name="exception_install_failed_dexopt">DEX优化失败</string>
     <string name="exception_install_failed_older_sdk">系统版本过旧，请先升级系统</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -98,6 +98,7 @@
     <string name="config_authorizer_global">跟隨全局</string>
     <string name="config_authorizer_global_desc">跟隨全局 （%1$s）</string>
     <string name="config_authorizer_none">無</string>
+    <string name="config_authorizer_none_tips">使用系統安裝器時，此處的大多數選項將無效。</string>
     <string name="config_authorizer_root">ROOT超级使用者</string>
     <string name="config_authorizer_shizuku">Shizuku</string>
     <string name="config_authorizer_dhizuku">Dhizuku</string>
@@ -310,6 +311,7 @@
     <string name="exception_install_failed_update_incompatible">更新失敗（簽名或其他原因），請解除安裝後安裝</string>
     <string name="exception_install_failed_shared_user_incompatible">與共享UID的程序簽名衝突</string>
     <string name="exception_install_failed_missing_shared_library">缺失共享庫</string>
+    <string name="exception_install_failed_missing_install_permission">請授予未知安裝來源權限然後重試</string>
     <string name="exception_install_failed_replace_couldnt_delete">無效的共享庫</string>
     <string name="exception_install_failed_dexopt">DEX優化失敗</string>
     <string name="exception_install_failed_older_sdk">系统版本過舊，請先升級系統</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,6 +104,7 @@
     <string name="config_authorizer_global">Global</string>
     <string name="config_authorizer_global_desc">Global (%1$s)</string>
     <string name="config_authorizer_none">None</string>
+    <string name="config_authorizer_none_tips">When using system installer, most of the options here are invalid.</string>
     <string name="config_authorizer_root">Root</string>
     <string name="config_authorizer_shizuku">Shizuku</string>
     <string name="config_authorizer_dhizuku">Dhizuku</string>
@@ -327,6 +328,7 @@
     <string name="exception_install_failed_update_incompatible">Update incompatible, please uninstall and try again</string>
     <string name="exception_install_failed_shared_user_incompatible">Package signatures don\'t match</string>
     <string name="exception_install_failed_missing_shared_library">Missing shared library</string>
+    <string name="exception_install_failed_missing_install_permission">Please grant install unknown apps permission and try again</string>
     <string name="exception_install_failed_replace_couldnt_delete">Invalid shared library</string>
     <string name="exception_install_failed_dexopt">Couldn\'t optimize DEX</string>
     <string name="exception_install_failed_older_sdk">The system version is too old, please upgrade the system</string>


### PR DESCRIPTION
This PR introduces a new "None" authorizer option, which utilizes the standard Android system installer (`PackageInstaller`).

Key changes include:
*   A new `NoneInstallerRepoImpl` that handles installation via system APIs.
*   It checks for and requests the `REQUEST_INSTALL_PACKAGES` permission if not granted.
*   A corresponding `InstallFailedMissingInstallPermissionException` is added to handle cases where the permission is denied, with a "Retry" option in the failure dialog.
*   The "None" authorizer option is now conditionally displayed, hidden on Xiaomi devices where it is not applicable.
*   A tip card is displayed in the configuration UI to inform users that most installer options are invalid when using the "None" authorizer.
*   The `AndroidManifest.xml` is updated to include necessary permissions (`REQUEST_INSTALL_PACKAGES`, `REQUEST_DELETE_PACKAGES`).
*   Introduced `isM3E` parameter to `SwitchWidget` to control M3-style icons, disabling it for legacy UI pages to maintain a consistent look.
*   Cancelled preset installation blacklist for sharedUID

Note: This feature is not available for Xiaomi so disabled.