### PR TITLE
feat: refine package installation intent filter with specific MIME types

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -90,17 +90,69 @@
             android:launchMode="singleInstance"
             android:theme="@style/Theme.Installer.Translucent">
 
+            <!--
+                For intents with type */*
+                Android 8+: mimeType-only
+            -->
             <intent-filter android:priority="10">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.INSTALL_PACKAGE" />
-
                 <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="application/apk" />
+                <data android:mimeType="application/apk.1" />
+                <data android:mimeType="application/apkm" />
+                <data android:mimeType="application/apk.1m" />
+                <data android:mimeType="application/apks" />
+                <data android:mimeType="application/apk.1s" />
+                <data android:mimeType="application/octet-stream" />
+                <data android:mimeType="application/vnd.android.package-archive" />
+                <data android:mimeType="application/vnd.apkm" />
+                <data android:mimeType="application/vnd.apks" />
+                <data android:mimeType="application/xapk" />
+                <data android:mimeType="application/xapk-package-archive" />
+                <data android:mimeType="application/zip" />
+            </intent-filter>
 
+            <!--
+                For intents with type null
+                Android 12+: pathPattern + patterSuffix
+                Android 8-11: pathPattern-only
+            -->
+            <intent-filter android:priority="10">
+                <action android:name="android.intent.action.VIEW" />
+                <action android:name="android.intent.action.INSTALL_PACKAGE" />
+                <category android:name="android.intent.category.DEFAULT" />
                 <data android:scheme="content" />
                 <data android:scheme="file" />
-                <data android:mimeType="application/vnd.android.package-archive" />
-                <data android:pathPattern=".*" />
-                <data android:mimeType="*/*" />
+                <data android:host="*" />
+                <data android:pathPattern=".*\.apk" />
+                <data android:pathPattern=".*\.apk\.1" />
+                <data android:pathPattern=".*\.apkm" />
+                <data android:pathPattern=".*\.apk\.1m" />
+                <data android:pathPattern=".*\.apks" />
+                <data android:pathPattern=".*\.apk\.1s" />
+                <data android:pathPattern=".*\.xapk" />
+                <data android:pathPattern=".*\.zip" />
+                <data android:pathPattern=".*\.APK" />
+                <data android:pathPattern=".*\.APK\.1" />
+                <data android:pathPattern=".*\.APKM" />
+                <data android:pathPattern=".*\.APKS" />
+                <data android:pathPattern=".*\.XAPK" />
+                <data android:pathPattern=".*\.ZIP" />
+                <data android:pathSuffix=".apk" />
+                <data android:pathSuffix=".apk.1" />
+                <data android:pathSuffix=".apkm" />
+                <data android:pathSuffix=".apk.1m" />
+                <data android:pathSuffix=".apks" />
+                <data android:pathSuffix=".apk.1s" />
+                <data android:pathSuffix=".xapk" />
+                <data android:pathSuffix=".zip" />
+                <data android:pathSuffix=".APK" />
+                <data android:pathSuffix=".APK.1" />
+                <data android:pathSuffix=".APKM" />
+                <data android:pathSuffix=".APKS" />
+                <data android:pathSuffix=".XAPK" />
+                <data android:pathSuffix=".ZIP" />
             </intent-filter>
 
             <intent-filter>


### PR DESCRIPTION
This PR fixes an issue where the installer was showing up as an option for opening unrelated files like `.txt` or `.pdf`.

- Replaced broad `*/*` MIME type and unused `pathPattern` with explicit types to improve intent targeting and reduce over-exposure in the intent picker.
- Added support for specialized package formats: `.apkm`, `.apks`, `.xapk`, and `.zip`.
- Included `application/octet-stream` for generic binary data handling.