### PR TITLE
fix(#708): correct dynamic color extraction fallback on Android 11 and below

### DIFF
--- a/app/src/main/java/com/rosan/installer/data/settings/provider/ThemeStateProviderImpl.kt
+++ b/app/src/main/java/com/rosan/installer/data/settings/provider/ThemeStateProviderImpl.kt
@@ -36,7 +36,7 @@ class ThemeStateProviderImpl(
                     if (wallpaperColors.contains(manualSeedColor)) {
                         manualSeedColor
                     } else wallpaperColors[0]
-                } else PresetColors[0].color.toArgb()
+                } else manualSeedColor
             } else if (PresetColors.any { it.color.toArgb() == manualSeedColor }) {
                 manualSeedColor
             } else PresetColors[0].color.toArgb()

--- a/app/src/main/java/com/rosan/installer/data/settings/provider/ThemeStateProviderImpl.kt
+++ b/app/src/main/java/com/rosan/installer/data/settings/provider/ThemeStateProviderImpl.kt
@@ -29,7 +29,11 @@ class ThemeStateProviderImpl(
         val manualSeedColor = prefs.seedColorInt
         val effectiveSeedColor =
             if (prefs.useDynamicColor && Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
-                if (!wallpaperColors.isNullOrEmpty()) wallpaperColors[0] else manualSeedColor
+                if (!wallpaperColors.isNullOrEmpty()) {
+                    if (wallpaperColors.contains(manualSeedColor)) {
+                        manualSeedColor
+                    } else wallpaperColors[0]
+                } else manualSeedColor
             } else manualSeedColor
 
         ThemeState(

--- a/app/src/main/java/com/rosan/installer/data/settings/provider/ThemeStateProviderImpl.kt
+++ b/app/src/main/java/com/rosan/installer/data/settings/provider/ThemeStateProviderImpl.kt
@@ -3,10 +3,12 @@
 package com.rosan.installer.data.settings.provider
 
 import android.os.Build
+import androidx.compose.ui.graphics.toArgb
 import com.kieronquinn.monetcompat.core.MonetCompat
 import com.rosan.installer.domain.settings.model.preferences.ThemeState
 import com.rosan.installer.domain.settings.provider.ThemeStateProvider
 import com.rosan.installer.domain.settings.repository.AppSettingsRepository
+import com.rosan.installer.ui.theme.material.PresetColors
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -27,14 +29,17 @@ class ThemeStateProviderImpl(
         getWallpaperColorsFlow()
     ) { prefs, wallpaperColors ->
         val manualSeedColor = prefs.seedColorInt
-        val effectiveSeedColor =
+
+        val effectiveSeedColor: Int =
             if (prefs.useDynamicColor && Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
                 if (!wallpaperColors.isNullOrEmpty()) {
                     if (wallpaperColors.contains(manualSeedColor)) {
                         manualSeedColor
                     } else wallpaperColors[0]
-                } else manualSeedColor
-            } else manualSeedColor
+                } else PresetColors[0].color.toArgb()
+            } else if (PresetColors.any { it.color.toArgb() == manualSeedColor }) {
+                manualSeedColor
+            } else PresetColors[0].color.toArgb()
 
         ThemeState(
             isLoaded = true,

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/theme/ThemeSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/theme/ThemeSettingsPage.kt
@@ -381,8 +381,9 @@ fun ThemeSettingsPage(
                                                             colorSpec = uiState.colorSpec,
                                                             textStyle = MaterialTheme.typography.labelMedium.copy(fontSize = 13.sp),
                                                             textColor = MaterialTheme.colorScheme.onSurface,
-                                                            isSelected = uiState.seedColor == rawColor.color &&
-                                                                    !(uiState.useDynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S),
+                                                            isSelected =
+                                                                uiState.seedColor == rawColor.color
+                                                                && !(uiState.useDynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S),
                                                         ) {
                                                             viewModel.dispatch(ThemeSettingsAction.SetSeedColor(rawColor.color))
                                                         }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/theme/ThemeSettingsViewModel.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/theme/ThemeSettingsViewModel.kt
@@ -35,23 +35,26 @@ class ThemeSettingsViewModel(
         systemEnvProvider.getWallpaperColorsFlow().onStart { emit(emptyList()) }
     ) { prefs, wallpaperColors ->
         val manualSeedColor = Color(prefs.seedColorInt)
-        val effectiveSeedColor: Color = if (prefs.useDynamicColor && Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
-            if (!wallpaperColors.isNullOrEmpty()) {
-                if (wallpaperColors.contains(manualSeedColor.toArgb())) {
-                    manualSeedColor
-                } else Color(wallpaperColors[0])
-            } else manualSeedColor
-        } else {
-            if (PresetColors.any { it.color == manualSeedColor }) manualSeedColor else PresetColors[0].color
-        }
 
-        val availableColors: List<RawColor> = if (prefs.useDynamicColor && Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
-            if (!wallpaperColors.isNullOrEmpty()) {
-                wallpaperColors.map { colorInt ->
-                    RawColor(key = colorInt.toHexString(), color = Color(colorInt))
-                }
+        val effectiveSeedColor: Color =
+            if (prefs.useDynamicColor && Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+                if (!wallpaperColors.isNullOrEmpty()) {
+                    if (wallpaperColors.contains(manualSeedColor.toArgb())) {
+                        manualSeedColor
+                    } else Color(wallpaperColors[0])
+                } else PresetColors[0].color
+            } else if (PresetColors.any { it.color == manualSeedColor }) {
+                manualSeedColor
+            } else PresetColors[0].color
+
+        val availableColors: List<RawColor> =
+            if (prefs.useDynamicColor && Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+                if (!wallpaperColors.isNullOrEmpty()) {
+                    wallpaperColors.map { colorInt ->
+                        RawColor(key = colorInt.toHexString(), color = Color(colorInt))
+                    }
+                } else PresetColors
             } else PresetColors
-        } else PresetColors
 
         ThemeSettingsState(
             showMiuixUI = prefs.showMiuixUI,
@@ -85,7 +88,12 @@ class ThemeSettingsViewModel(
             is ThemeSettingsAction.SetThemeMode -> viewModelScope.launch { updateSetting(StringSetting.ThemeMode, action.mode.name) }
             is ThemeSettingsAction.SetPaletteStyle -> viewModelScope.launch { updateSetting(StringSetting.ThemePaletteStyle, action.style.name) }
             is ThemeSettingsAction.SetColorSpec -> viewModelScope.launch { updateSetting(StringSetting.ThemeColorSpec, action.spec.name) }
-            is ThemeSettingsAction.SetUseDynamicColor -> viewModelScope.launch { updateSetting(BooleanSetting.ThemeUseDynamicColor, action.use) }
+
+            is ThemeSettingsAction.SetUseDynamicColor -> viewModelScope.launch {
+                updateSetting(BooleanSetting.ThemeUseDynamicColor, action.use)
+                updateSetting(IntSetting.ThemeSeedColor, Int.MIN_VALUE)
+            }
+
             is ThemeSettingsAction.SetUseMiuixMonet -> viewModelScope.launch { updateSetting(BooleanSetting.UiUseMiuixMonet, action.use) }
             is ThemeSettingsAction.SetUseAppleFloatingBar -> viewModelScope.launch {
                 updateSetting(

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/theme/ThemeSettingsViewModel.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/theme/ThemeSettingsViewModel.kt
@@ -42,7 +42,7 @@ class ThemeSettingsViewModel(
                     if (wallpaperColors.contains(manualSeedColor.toArgb())) {
                         manualSeedColor
                     } else Color(wallpaperColors[0])
-                } else PresetColors[0].color
+                } else manualSeedColor
             } else if (PresetColors.any { it.color == manualSeedColor }) {
                 manualSeedColor
             } else PresetColors[0].color

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/theme/MiuixThemeSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/theme/MiuixThemeSettingsPage.kt
@@ -296,8 +296,9 @@ fun MiuixThemeSettingsPage(
                                                         colorSpec = uiState.colorSpec,
                                                         textStyle = MiuixTheme.textStyles.footnote1,
                                                         textColor = MiuixTheme.colorScheme.onSurface,
-                                                        isSelected = uiState.seedColor == rawColor.color &&
-                                                                !(uiState.useDynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S),
+                                                        isSelected =
+                                                            uiState.seedColor == rawColor.color
+                                                            && !(uiState.useDynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S),
                                                     ) {
                                                         viewModel.dispatch(
                                                             ThemeSettingsAction.SetSeedColor(


### PR DESCRIPTION
修复 #708
此外，切换动态颜色选项时会自动重置SeedColor

Fixed #708
Additionally, the SeedColor will automatically reset when switching the dynamic color option.