### PR TITLE
refactor: 简化设置页 Insets 处理并修复底部双重边距

### DIFF
--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/SettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/SettingsPage.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -182,13 +183,13 @@ fun Material3SettingsWideScreenLayout(
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxSize()
+                    .consumeWindowInsets(navigationWindowInsets.only(WindowInsetsSides.Start))
                     .then(backdrop?.let { Modifier.layerBackdrop(backdrop) } ?: Modifier),
                 configCount = configCount,
                 mainPagerState = mainPagerState,
                 tabs = tabs,
                 useBlur = useBlur,
-                outerPadding = PaddingValues(0.dp), // Rail navigation doesn't overlay bottom content
-                windowInsetsSides = WindowInsetsSides.Vertical + WindowInsetsSides.End
+                outerPadding = PaddingValues(0.dp) // Rail navigation doesn't overlay bottom content
             )
         }
     }
@@ -276,8 +277,7 @@ private fun Material3SettingsPagerContent(
     mainPagerState: MainPagerState,
     tabs: List<NavigationTab>,
     useBlur: Boolean,
-    outerPadding: PaddingValues,
-    windowInsetsSides: WindowInsetsSides? = null
+    outerPadding: PaddingValues
 ) {
     HorizontalPager(
         state = mainPagerState.pagerState,
@@ -291,29 +291,25 @@ private fun Material3SettingsPagerContent(
                 title = tabs[page].label,
                 outerPadding = outerPadding,
                 configCount = configCount,
-                onNavigateToProfiles = { mainPagerState.animateToPage(1) },
-                windowInsetsSides = windowInsetsSides
+                onNavigateToProfiles = { mainPagerState.animateToPage(1) }
             )
 
             1 -> AllPage(
                 useBlur = useBlur,
                 title = tabs[page].label,
-                outerPadding = outerPadding,
-                windowInsetsSides = windowInsetsSides
+                outerPadding = outerPadding
             )
 
             2 -> HistoryPage(
                 useBlur = useBlur,
                 title = tabs[page].label,
-                outerPadding = outerPadding,
-                windowInsetsSides = windowInsetsSides
+                outerPadding = outerPadding
             )
 
             3 -> PreferredPage(
                 useBlur = useBlur,
                 title = tabs[page].label,
-                outerPadding = outerPadding,
-                windowInsetsSides = windowInsetsSides
+                outerPadding = outerPadding
             )
         }
     }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/SettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/SettingsPage.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
@@ -23,6 +22,7 @@ import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.material3.Badge
@@ -120,6 +120,7 @@ fun Material3SettingsCompactLayout(
         Material3SettingsPagerContent(
             modifier = Modifier
                 .fillMaxSize()
+                .consumeWindowInsets(paddingValues)
                 .then(backdrop?.let { Modifier.layerBackdrop(backdrop) } ?: Modifier),
             configCount = configCount,
             mainPagerState = mainPagerState,
@@ -162,6 +163,7 @@ fun Material3SettingsWideScreenLayout(
             Material3SettingsPagerContent(
                 modifier = Modifier
                     .fillMaxSize()
+                    .consumeWindowInsets(paddingValues)
                     .then(backdrop?.let { Modifier.layerBackdrop(backdrop) } ?: Modifier),
                 configCount = configCount,
                 mainPagerState = mainPagerState,
@@ -216,10 +218,8 @@ private fun Material3FloatingBottomBar(
                     indication = null,
                     onClick = {},
                 )
-                .padding(
-                    bottom = 12.dp + WindowInsets.navigationBars.asPaddingValues()
-                        .calculateBottomPadding()
-                ),
+                .padding(bottom = 12.dp)
+                .windowInsetsPadding(WindowInsets.navigationBars.only(WindowInsetsSides.Bottom)),
             selectedIndex = { mainPagerState.selectedPage },
             onSelected = { index ->
                 mainPagerState.animateToPage(index)

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/all/AllPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/all/AllPage.kt
@@ -40,7 +40,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.SmallExtendedFloatingActionButton
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -85,8 +84,7 @@ fun AllPage(
     useBlur: Boolean,
     viewModel: AllViewModel = koinViewModel(),
     title: String,
-    outerPadding: PaddingValues = PaddingValues(0.dp),
-    windowInsetsSides: WindowInsetsSides? = null
+    outerPadding: PaddingValues = PaddingValues(0.dp)
 ) {
     val navigator = LocalNavigator.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -141,13 +139,9 @@ fun AllPage(
             .fillMaxSize()
             .nestedScroll(scrollBehavior.nestedScrollConnection),
         containerColor = MaterialTheme.colorScheme.surfaceContainer,
-        contentWindowInsets = windowInsetsSides?.let { ScaffoldDefaults.contentWindowInsets.only(it) }
-            ?: ScaffoldDefaults.contentWindowInsets,
         topBar = {
             LargeFlexibleTopAppBar(
                 modifier = Modifier.installerMaterial3BlurEffect(backdrop),
-                windowInsets = windowInsetsSides?.let { TopAppBarDefaults.windowInsets.only(it) }
-                    ?: TopAppBarDefaults.windowInsets,
                 title = {
                     Text(
                         text = title,

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/all/AllPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/all/AllPage.kt
@@ -13,17 +13,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.plus
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -56,7 +50,6 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -130,8 +123,6 @@ fun AllPage(
         }
     )
 
-    val layoutDirection = LocalLayoutDirection.current
-
     val backdrop = rememberMaterial3BlurBackdrop(useBlur)
 
     Scaffold(
@@ -159,10 +150,7 @@ fun AllPage(
         floatingActionButton = {
             AnimatedVisibility(
                 modifier = Modifier
-                    .padding(
-                        bottom = outerPadding.calculateBottomPadding()
-                    )
-                    .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.End)),
+                    .padding(outerPadding),
                 visible = showFloating,
                 enter = scaleIn(),
                 exit = scaleOut()
@@ -196,10 +184,7 @@ fun AllPage(
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
-                            .padding(
-                                top = innerPadding.calculateTopPadding(),
-                                bottom = outerPadding.calculateBottomPadding()
-                            ),
+                            .padding(innerPadding + outerPadding),
                         contentAlignment = Alignment.Center
                     ) {
                         Column(
@@ -228,16 +213,7 @@ fun AllPage(
                         viewModel = viewModel,
                         listState = listState,
                         backdrop = backdrop,
-                        contentPadding = PaddingValues(
-                            top = innerPadding.calculateTopPadding() + 16.dp,
-                            bottom = outerPadding.calculateBottomPadding() + 16.dp,
-                            start = 16.dp + innerPadding.calculateStartPadding(layoutDirection) + outerPadding.calculateStartPadding(
-                                layoutDirection
-                            ),
-                            end = 16.dp + innerPadding.calculateEndPadding(layoutDirection) + outerPadding.calculateEndPadding(
-                                layoutDirection
-                            )
-                        )
+                        contentPadding = PaddingValues(16.dp) + outerPadding + innerPadding
                     )
                 }
             }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/apply/ApplyPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/apply/ApplyPage.kt
@@ -20,17 +20,12 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.add
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -131,7 +126,6 @@ fun ApplyPage(
     }
 
     val layoutDirection = LocalLayoutDirection.current
-    val horizontalSafeInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal).asPaddingValues()
 
     val backdrop = rememberMaterial3BlurBackdrop(useBlur)
 
@@ -223,7 +217,6 @@ fun ApplyPage(
                 enter = scaleIn(),
                 exit = scaleOut(),
                 modifier = Modifier.padding(
-                    end = horizontalSafeInsets.calculateEndPadding(layoutDirection),
                     bottom = 16.dp
                 )
             ) {
@@ -289,8 +282,8 @@ fun ApplyPage(
                             lazyListState = lazyListState,
                             topPadding = paddingValues.calculateTopPadding(),
                             bottomPadding = paddingValues.calculateBottomPadding(),
-                            startPadding = horizontalSafeInsets.calculateStartPadding(layoutDirection),
-                            endPadding = horizontalSafeInsets.calculateEndPadding(layoutDirection)
+                            startPadding = paddingValues.calculateStartPadding(layoutDirection),
+                            endPadding = paddingValues.calculateEndPadding(layoutDirection)
                         )
                     }
                 }
@@ -328,7 +321,7 @@ private fun ItemsWidget(
             start = startPadding + 16.dp,
             top = topPadding + 8.dp,
             end = endPadding + 16.dp,
-            bottom = bottomPadding + 88.dp
+            bottom = bottomPadding + 96.dp
         )
     ) {
         val apps = uiState.checkedApps
@@ -371,11 +364,15 @@ private fun ItemsWidget(
                     viewModel.dispatch(ApplyViewAction.ApplyPackageName(app.packageName, isChecked))
                 },
                 onClick = {
-                    viewModel.dispatch(ApplyViewAction.ApplyPackageName(app.packageName, !isApplied))
+                    viewModel.dispatch(
+                        ApplyViewAction.ApplyPackageName(
+                            app.packageName,
+                            !isApplied
+                        )
+                    )
                 }
             )
         }
-        item { Spacer(modifier = Modifier.navigationBarsPadding()) }
     }
 }
 

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/edit/EditPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/edit/EditPage.kt
@@ -12,23 +12,17 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.add
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.plus
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
@@ -49,7 +43,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -150,8 +143,6 @@ fun EditPage(
     EditEventCollector(viewModel, snackBarHostState)
 
     val focusManager = LocalFocusManager.current
-    val layoutDirection = LocalLayoutDirection.current
-    val horizontalSafeInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal).asPaddingValues()
 
     val backdrop = rememberMaterial3BlurBackdrop(useBlur)
 
@@ -192,7 +183,6 @@ fun EditPage(
         floatingActionButton = {
             SmallExtendedFloatingActionButton(
                 modifier = Modifier.padding(
-                    end = horizontalSafeInsets.calculateEndPadding(layoutDirection),
                     bottom = 16.dp
                 ),
                 icon = {
@@ -216,12 +206,7 @@ fun EditPage(
             modifier = Modifier
                 .fillMaxSize()
                 .then(backdrop?.let { Modifier.layerBackdrop(it) } ?: Modifier),
-            contentPadding = PaddingValues(
-                start = horizontalSafeInsets.calculateStartPadding(layoutDirection),
-                top = paddingValues.calculateTopPadding(),
-                end = horizontalSafeInsets.calculateEndPadding(layoutDirection),
-                bottom = paddingValues.calculateBottomPadding() + 80.dp
-            ),
+            contentPadding = paddingValues + PaddingValues(bottom = 96.dp),
             state = listState,
         ) {
             // --- Group 1: Main Settings ---
@@ -229,7 +214,12 @@ fun EditPage(
                 SegmentedColumn(
                     title = stringResource(R.string.config_label_main_settings)
                 ) {
-                    item { DataNameWidget(state, dispatch, { DataDescriptionWidget(state, dispatch) }) }
+                    item {
+                        DataNameWidget(
+                            state,
+                            dispatch,
+                            { DataDescriptionWidget(state, dispatch) })
+                    }
                     dataAuthorizerWidget(state, dispatch)
                     item { DataInstallModeWidget(state, dispatch) }
                     item {
@@ -275,9 +265,19 @@ fun EditPage(
                     item { DataForAllUserWidget(state, dispatch) }
                     item { DataAllowTestOnlyWidget(state, dispatch) }
                     item { DataAllowDowngradeWidget(state, dispatch) }
-                    if (isAtLeastUpsideDownCake) item { DataBypassLowTargetSdkWidget(state, dispatch) }
+                    if (isAtLeastUpsideDownCake) item {
+                        DataBypassLowTargetSdkWidget(
+                            state,
+                            dispatch
+                        )
+                    }
                     item { DataAllowAllRequestedPermissionsWidget(state, dispatch) }
-                    if (isAtLeastUpsideDownCake) item { DataRequestUpdateOwnershipWidget(state, dispatch) }
+                    if (isAtLeastUpsideDownCake) item {
+                        DataRequestUpdateOwnershipWidget(
+                            state,
+                            dispatch
+                        )
+                    }
                 }
             }
 
@@ -294,8 +294,6 @@ fun EditPage(
                     }
                 }
             }
-
-            item { Spacer(Modifier.navigationBarsPadding()) }
         }
     }
 }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryPage.kt
@@ -11,14 +11,12 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
@@ -36,7 +34,6 @@ import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -87,8 +84,7 @@ fun HistoryPage(
     useBlur: Boolean,
     viewModel: HistoryViewModel = koinViewModel(),
     title: String,
-    outerPadding: PaddingValues = PaddingValues(0.dp),
-    windowInsetsSides: WindowInsetsSides? = null
+    outerPadding: PaddingValues = PaddingValues(0.dp)
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val topAppBarState = rememberTopAppBarState()
@@ -108,13 +104,9 @@ fun HistoryPage(
             .nestedScroll(scrollBehavior.nestedScrollConnection)
             .fillMaxSize(),
         containerColor = MaterialTheme.colorScheme.surfaceContainer,
-        contentWindowInsets = windowInsetsSides?.let { ScaffoldDefaults.contentWindowInsets.only(it) }
-            ?: ScaffoldDefaults.contentWindowInsets,
         topBar = {
             LargeFlexibleTopAppBar(
                 modifier = Modifier.installerMaterial3BlurEffect(backdrop),
-                windowInsets = windowInsetsSides?.let { TopAppBarDefaults.windowInsets.only(it) }
-                    ?: TopAppBarDefaults.windowInsets,
                 title = {
                     Text(
                         text = title,
@@ -474,7 +466,9 @@ private fun HistoryInfoLine(
                 detectTapGestures(
                     onLongPress = {
                         coroutineScope.launch {
-                            clipboard.setClipEntry(ClipData.newPlainText(title, value).toClipEntry())
+                            clipboard.setClipEntry(
+                                ClipData.newPlainText(title, value).toClipEntry()
+                            )
                         }
                         context.toast(R.string.copied_format, value)
                     }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/home/HomePage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/home/HomePage.kt
@@ -10,13 +10,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -31,7 +29,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -71,8 +68,7 @@ fun HomePage(
     title: String,
     outerPadding: PaddingValues,
     configCount: Int = 0,
-    onNavigateToProfiles: () -> Unit = {},
-    windowInsetsSides: WindowInsetsSides? = null
+    onNavigateToProfiles: () -> Unit = {}
 ) {
     val navigator = LocalNavigator.current
     val uriHandler = LocalUriHandler.current
@@ -90,13 +86,9 @@ fun HomePage(
             .nestedScroll(scrollBehavior.nestedScrollConnection)
             .fillMaxSize(),
         containerColor = MaterialTheme.colorScheme.surfaceContainer,
-        contentWindowInsets = windowInsetsSides?.let { ScaffoldDefaults.contentWindowInsets.only(it) }
-            ?: ScaffoldDefaults.contentWindowInsets,
         topBar = {
             LargeFlexibleTopAppBar(
                 modifier = Modifier.installerMaterial3BlurEffect(backdrop),
-                windowInsets = windowInsetsSides?.let { TopAppBarDefaults.windowInsets.only(it) }
-                    ?: TopAppBarDefaults.windowInsets,
                 title = {
                     Text(
                         text = title,

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/home/HomePage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/home/HomePage.kt
@@ -10,12 +10,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.plus
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
@@ -37,7 +35,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -74,7 +71,6 @@ fun HomePage(
     val uriHandler = LocalUriHandler.current
     val uiState by viewModel.state.collectAsStateWithLifecycle()
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
-    val layoutDirection = LocalLayoutDirection.current
     val backdrop = rememberMaterial3BlurBackdrop(useBlur)
 
     OnLifecycleEvent(event = Lifecycle.Event.ON_RESUME) {
@@ -108,16 +104,7 @@ fun HomePage(
             modifier = Modifier
                 .fillMaxSize()
                 .then(backdrop?.let { Modifier.layerBackdrop(it) } ?: Modifier),
-            contentPadding = PaddingValues(
-                start = 16.dp + paddingValues.calculateStartPadding(layoutDirection) + outerPadding.calculateStartPadding(
-                    layoutDirection
-                ),
-                top = paddingValues.calculateTopPadding() + 16.dp,
-                end = 16.dp + paddingValues.calculateEndPadding(layoutDirection) + outerPadding.calculateEndPadding(
-                    layoutDirection
-                ),
-                bottom = outerPadding.calculateBottomPadding()
-            )
+            contentPadding = PaddingValues(16.dp) + paddingValues + outerPadding
         ) {
             item {
                 InstallerStatusCard(
@@ -216,7 +203,7 @@ fun HomePage(
             item {
                 SegmentedColumn(
                     title = stringResource(R.string.home_learn_more_title),
-                    contentPadding = PaddingValues(top = 16.dp, bottom = 8.dp)
+                    contentPadding = PaddingValues(top = 16.dp)
                 ) {
                     item {
                         BaseWidget(
@@ -228,7 +215,6 @@ fun HomePage(
                     }
                 }
             }
-            item { Spacer(Modifier.navigationBarsPadding()) }
         }
     }
 }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/home/installer/DefaultInstallerPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/home/installer/DefaultInstallerPage.kt
@@ -9,22 +9,14 @@ import android.os.SystemClock
 import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.add
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
@@ -49,7 +41,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextDecoration
@@ -89,9 +80,6 @@ fun DefaultInstallerPage(
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(topAppBarState)
 
-    val layoutDirection = LocalLayoutDirection.current
-    val horizontalSafeInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal).asPaddingValues()
-
     val backdrop = rememberMaterial3BlurBackdrop(useBlur)
 
     var errorDialogInfo by remember {
@@ -123,7 +111,11 @@ fun DefaultInstallerPage(
             when (event) {
                 is HomePageViewEvent.ShowDefaultInstallerResult -> {
                     dismissDefaultInstallerProgress()
-                    Toast.makeText(context, context.getString(event.messageResId), Toast.LENGTH_SHORT).show()
+                    Toast.makeText(
+                        context,
+                        context.getString(event.messageResId),
+                        Toast.LENGTH_SHORT
+                    ).show()
                 }
 
                 is HomePageViewEvent.ShowDefaultInstallerErrorDetail -> {
@@ -165,12 +157,7 @@ fun DefaultInstallerPage(
             modifier = Modifier
                 .fillMaxSize()
                 .then(backdrop?.let { Modifier.layerBackdrop(it) } ?: Modifier),
-            contentPadding = PaddingValues(
-                start = horizontalSafeInsets.calculateStartPadding(layoutDirection),
-                top = paddingValues.calculateTopPadding(),
-                end = horizontalSafeInsets.calculateEndPadding(layoutDirection),
-                bottom = paddingValues.calculateBottomPadding()
-            )
+            contentPadding = paddingValues
         ) {
             when {
                 uiState.isSystemApp -> item { InfoTipCard(stringResource(R.string.config_authorizer_none_system_app_tips)) }
@@ -229,7 +216,13 @@ fun DefaultInstallerPage(
                                 title = stringResource(R.string.setting_lsposed_module_title),
                                 description = stringResource(R.string.setting_lsposed_module_desc),
                                 checked = uiState.userSetLSPosedActive,
-                                onCheckedChange = { viewModel.dispatch(HomePageViewAction.ChangeUserSetLSPosedActive(it)) }
+                                onCheckedChange = {
+                                    viewModel.dispatch(
+                                        HomePageViewAction.ChangeUserSetLSPosedActive(
+                                            it
+                                        )
+                                    )
+                                }
                             )
                         }
                     }
@@ -273,7 +266,6 @@ fun DefaultInstallerPage(
                 }
             }
 
-            item { Spacer(Modifier.navigationBarsPadding()) }
         }
     }
 

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/home/priv/PrivPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/home/priv/PrivPage.kt
@@ -4,19 +4,11 @@
 
 package com.rosan.installer.ui.page.main.settings.home.priv
 
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.add
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -32,7 +24,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
@@ -66,9 +57,6 @@ fun PrivPage(
     val uiState by viewModel.state.collectAsStateWithLifecycle()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(topAppBarState)
-
-    val layoutDirection = LocalLayoutDirection.current
-    val horizontalSafeInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal).asPaddingValues()
 
     OnLifecycleEvent(event = Lifecycle.Event.ON_RESUME) {
         viewModel.dispatch(HomePageViewAction.RefreshActivateStatus)
@@ -107,12 +95,7 @@ fun PrivPage(
             modifier = Modifier
                 .fillMaxSize()
                 .then(backdrop?.let { Modifier.layerBackdrop(it) } ?: Modifier),
-            contentPadding = PaddingValues(
-                start = horizontalSafeInsets.calculateStartPadding(layoutDirection),
-                top = paddingValues.calculateTopPadding(),
-                end = horizontalSafeInsets.calculateEndPadding(layoutDirection),
-                bottom = paddingValues.calculateBottomPadding()
-            )
+            contentPadding = paddingValues
         ) {
             item {
                 SegmentedColumn {
@@ -120,11 +103,19 @@ fun PrivPage(
                         val selected = uiState.globalAuthorizer == Authorizer.None
                         RadioButtonWidget(
                             icon = AppIcons.None,
-                            title = if (uiState.isSystemApp) stringResource(R.string.working_status_system_installer) else stringResource(R.string.config_authorizer_none),
+                            title = if (uiState.isSystemApp) stringResource(R.string.working_status_system_installer) else stringResource(
+                                R.string.config_authorizer_none
+                            ),
                             description = if (uiState.isSystemApp) stringResource(R.string.working_status_system_installer_desc)
                             else stringResource(R.string.working_status_none_authorizer_desc),
                             selected = selected,
-                            onClick = { viewModel.dispatch(HomePageViewAction.ChangeAuthorizer(Authorizer.None)) }
+                            onClick = {
+                                viewModel.dispatch(
+                                    HomePageViewAction.ChangeAuthorizer(
+                                        Authorizer.None
+                                    )
+                                )
+                            }
                         )
                     }
                     item {
@@ -136,7 +127,13 @@ fun PrivPage(
                             description = if (isAvailable) stringResource(R.string.available) + " (${uiState.rootMode.name})"
                             else stringResource(R.string.unavailable),
                             selected = selected,
-                            onClick = { viewModel.dispatch(HomePageViewAction.ChangeAuthorizer(Authorizer.Root)) }
+                            onClick = {
+                                viewModel.dispatch(
+                                    HomePageViewAction.ChangeAuthorizer(
+                                        Authorizer.Root
+                                    )
+                                )
+                            }
                         )
                     }
                     item {
@@ -150,7 +147,13 @@ fun PrivPage(
                                 else -> stringResource(R.string.shizuku_not_available)
                             },
                             selected = selected,
-                            onClick = { viewModel.dispatch(HomePageViewAction.ChangeAuthorizer(Authorizer.Shizuku)) }
+                            onClick = {
+                                viewModel.dispatch(
+                                    HomePageViewAction.ChangeAuthorizer(
+                                        Authorizer.Shizuku
+                                    )
+                                )
+                            }
                         )
                     }
                     item {
@@ -164,7 +167,13 @@ fun PrivPage(
                                 else -> stringResource(R.string.dhizuku_not_available)
                             },
                             selected = selected,
-                            onClick = { viewModel.dispatch(HomePageViewAction.ChangeAuthorizer(Authorizer.Dhizuku)) }
+                            onClick = {
+                                viewModel.dispatch(
+                                    HomePageViewAction.ChangeAuthorizer(
+                                        Authorizer.Dhizuku
+                                    )
+                                )
+                            }
                         )
                     }
                 }
@@ -181,7 +190,6 @@ fun PrivPage(
                     text = stringResource(R.string.priv_page_notice_desc)
                 )
             }
-            item { Spacer(Modifier.navigationBarsPadding()) }
         }
     }
 }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/PreferredPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/PreferredPage.kt
@@ -10,12 +10,10 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.AlertDialog
@@ -24,7 +22,6 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
@@ -79,8 +76,7 @@ fun PreferredPage(
     useBlur: Boolean,
     viewModel: PreferredViewModel = koinViewModel(),
     title: String,
-    outerPadding: PaddingValues = PaddingValues(0.dp),
-    windowInsetsSides: WindowInsetsSides? = null
+    outerPadding: PaddingValues = PaddingValues(0.dp)
 ) {
     val navigator = LocalNavigator.current
     val context = LocalContext.current
@@ -198,13 +194,9 @@ fun PreferredPage(
             .nestedScroll(scrollBehavior.nestedScrollConnection)
             .fillMaxSize(),
         containerColor = MaterialTheme.colorScheme.surfaceContainer,
-        contentWindowInsets = windowInsetsSides?.let { ScaffoldDefaults.contentWindowInsets.only(it) }
-            ?: ScaffoldDefaults.contentWindowInsets,
         topBar = {
             LargeFlexibleTopAppBar(
                 modifier = Modifier.installerMaterial3BlurEffect(backdrop),
-                windowInsets = windowInsetsSides?.let { TopAppBarDefaults.windowInsets.only(it) }
-                    ?: TopAppBarDefaults.windowInsets,
                 title = {
                     Text(
                         text = title,
@@ -329,7 +321,15 @@ fun PreferredPage(
                             title = stringResource(R.string.backup_settings_restore),
                             description = stringResource(R.string.backup_settings_restore_desc),
                             enabled = !uiState.backupBusy,
-                            onClick = { restoreLauncher.launch(arrayOf("application/json", "text/json", "*/*")) }
+                            onClick = {
+                                restoreLauncher.launch(
+                                    arrayOf(
+                                        "application/json",
+                                        "text/json",
+                                        "*/*"
+                                    )
+                                )
+                            }
                         )
                     }
                 }
@@ -442,7 +442,12 @@ private fun BackupRestorePreview.formatBackupRestorePreview(context: Context): S
         )
         if (ignoredSettingCount > 0) {
             append("\n")
-            append(context.getString(R.string.backup_settings_restore_ignored_settings, ignoredSettingCount))
+            append(
+                context.getString(
+                    R.string.backup_settings_restore_ignored_settings,
+                    ignoredSettingCount
+                )
+            )
         }
         if (warnings.isNotEmpty()) {
             append("\n\n")

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/PreferredPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/PreferredPage.kt
@@ -9,12 +9,9 @@ import android.content.Context
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.plus
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -39,7 +36,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
@@ -185,8 +181,6 @@ fun PreferredPage(
         }
     }
 
-    val layoutDirection = LocalLayoutDirection.current
-
     val backdrop = rememberMaterial3BlurBackdrop(useBlur)
 
     Scaffold(
@@ -222,16 +216,7 @@ fun PreferredPage(
             modifier = Modifier
                 .fillMaxSize()
                 .then(backdrop?.let { Modifier.layerBackdrop(it) } ?: Modifier),
-            contentPadding = PaddingValues(
-                start = paddingValues.calculateStartPadding(layoutDirection) + outerPadding.calculateStartPadding(
-                    layoutDirection
-                ),
-                top = paddingValues.calculateTopPadding(),
-                end = paddingValues.calculateEndPadding(layoutDirection) + outerPadding.calculateEndPadding(
-                    layoutDirection
-                ),
-                bottom = outerPadding.calculateBottomPadding()
-            )
+            contentPadding = paddingValues + outerPadding
         ) {
             // --- Global Settings Group ---
             item {
@@ -361,7 +346,6 @@ fun PreferredPage(
                     }
                 }
             }
-            item { Spacer(Modifier.navigationBarsPadding()) }
         }
     }
 

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/about/AboutPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/about/AboutPage.kt
@@ -4,21 +4,13 @@ package com.rosan.installer.ui.page.main.settings.preferred.about
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.add
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -45,7 +37,6 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -87,9 +78,6 @@ fun AboutPage(
 
     LogEventCollector(viewModel)
 
-    val layoutDirection = LocalLayoutDirection.current
-    val horizontalSafeInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal).asPaddingValues()
-
     val topBarBackdrop = rememberMaterial3BlurBackdrop(useBlur)
     val upgradeIndicatorBackdrop = rememberMaterial3BlurBackdrop(useBlur)
 
@@ -123,12 +111,7 @@ fun AboutPage(
             modifier = Modifier
                 .fillMaxSize()
                 .then(topBarBackdrop?.let { Modifier.layerBackdrop(it) } ?: Modifier),
-            contentPadding = PaddingValues(
-                start = horizontalSafeInsets.calculateStartPadding(layoutDirection),
-                top = paddingValues.calculateTopPadding(),
-                end = horizontalSafeInsets.calculateEndPadding(layoutDirection),
-                bottom = paddingValues.calculateBottomPadding()
-            ),
+            contentPadding = paddingValues,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             item {
@@ -190,7 +173,13 @@ fun AboutPage(
                                 title = stringResource(R.string.save_logs),
                                 description = stringResource(R.string.save_logs_desc),
                                 checked = uiState.enableFileLogging,
-                                onCheckedChange = { viewModel.dispatch(AboutAction.SetEnableFileLogging(it)) }
+                                onCheckedChange = {
+                                    viewModel.dispatch(
+                                        AboutAction.SetEnableFileLogging(
+                                            it
+                                        )
+                                    )
+                                }
                             )
                         }
                         item(animatedVisibility = uiState.enableFileLogging) {
@@ -203,7 +192,6 @@ fun AboutPage(
                         }
                     }
                 }
-            item { Spacer(Modifier.navigationBarsPadding()) }
         }
     }
     if (showBottomSheet) {

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/about/OpenSourceLicensePage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/about/OpenSourceLicensePage.kt
@@ -5,20 +5,13 @@ package com.rosan.installer.ui.page.main.settings.preferred.about
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.add
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -44,7 +37,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -82,9 +74,6 @@ fun OpenSourceLicensePage(useBlur: Boolean) {
 
     var selectedLibrary by remember { mutableStateOf<Library?>(null) }
 
-    val layoutDirection = LocalLayoutDirection.current
-    val horizontalSafeInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal).asPaddingValues()
-
     val backdrop = rememberMaterial3BlurBackdrop(useBlur)
 
     Scaffold(
@@ -118,12 +107,7 @@ fun OpenSourceLicensePage(useBlur: Boolean) {
             modifier = Modifier
                 .fillMaxSize()
                 .then(backdrop?.let { Modifier.layerBackdrop(it) } ?: Modifier),
-            contentPadding = PaddingValues(
-                start = horizontalSafeInsets.calculateStartPadding(layoutDirection) + 16.dp,
-                top = paddingValues.calculateTopPadding(),
-                end = horizontalSafeInsets.calculateEndPadding(layoutDirection) + 16.dp,
-                bottom = paddingValues.calculateBottomPadding()
-            ),
+            contentPadding = paddingValues,
             colors = LibraryDefaults.libraryColors(
                 libraryBackgroundColor = MaterialTheme.colorScheme.surfaceContainer,
                 libraryContentColor = MaterialTheme.colorScheme.onSurface
@@ -191,7 +175,9 @@ fun OpenSourceLicensePage(useBlur: Boolean) {
                         item {
                             InfoTipCard(
                                 icon = AppIcons.License,
-                                text = stringResource(R.string.license, library.licenses.joinToString(separator = ", ") { it.name }),
+                                text = stringResource(
+                                    R.string.license,
+                                    library.licenses.joinToString(separator = ", ") { it.name }),
                                 modifier = Modifier.fillMaxWidth(),
                                 noPadding = true
                             )
@@ -226,7 +212,8 @@ fun OpenSourceLicensePage(useBlur: Boolean) {
                                     Spacer(modifier = Modifier.size(8.dp))
 
                                     Text(
-                                        text = license.licenseContent ?: stringResource(R.string.no_license_text),
+                                        text = license.licenseContent
+                                            ?: stringResource(R.string.no_license_text),
                                         style = MaterialTheme.typography.bodySmall,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant
                                     )

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/installer/InstallerGlobalSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/installer/InstallerGlobalSettingsPage.kt
@@ -17,17 +17,10 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.add
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -61,7 +54,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -103,9 +95,6 @@ fun InstallerGlobalSettingsPage(
         topAppBarState.heightOffset = topAppBarState.heightOffsetLimit
     }
 
-    val layoutDirection = LocalLayoutDirection.current
-    val horizontalSafeInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal).asPaddingValues()
-
     val backdrop = rememberMaterial3BlurBackdrop(useBlur)
 
     Scaffold(
@@ -139,12 +128,7 @@ fun InstallerGlobalSettingsPage(
             modifier = Modifier
                 .fillMaxSize()
                 .then(backdrop?.let { Modifier.layerBackdrop(it) } ?: Modifier),
-            contentPadding = PaddingValues(
-                start = horizontalSafeInsets.calculateStartPadding(layoutDirection),
-                top = paddingValues.calculateTopPadding(),
-                end = horizontalSafeInsets.calculateEndPadding(layoutDirection),
-                bottom = paddingValues.calculateBottomPadding()
-            )
+            contentPadding = paddingValues
         ) {
             // --- Group 1: Global Installer Settings ---
             item {
@@ -206,7 +190,13 @@ fun InstallerGlobalSettingsPage(
                             title = stringResource(R.string.config_check_app_signature),
                             description = stringResource(R.string.config_check_app_signature_desc),
                             checked = uiState.checkAppSignature,
-                            onCheckedChange = { viewModel.dispatch(InstallerSettingsAction.ChangeCheckAppSignature(it)) }
+                            onCheckedChange = {
+                                viewModel.dispatch(
+                                    InstallerSettingsAction.ChangeCheckAppSignature(
+                                        it
+                                    )
+                                )
+                            }
                         )
                     }
 
@@ -217,7 +207,11 @@ fun InstallerGlobalSettingsPage(
                             description = stringResource(R.string.config_show_signature_info_on_match_desc),
                             checked = uiState.showSignatureInfoOnMatch,
                             onCheckedChange = {
-                                viewModel.dispatch(InstallerSettingsAction.ChangeShowSignatureInfoOnMatch(it))
+                                viewModel.dispatch(
+                                    InstallerSettingsAction.ChangeShowSignatureInfoOnMatch(
+                                        it
+                                    )
+                                )
                             }
                         )
                     }
@@ -229,7 +223,11 @@ fun InstallerGlobalSettingsPage(
                             description = stringResource(R.string.config_show_signature_details_desc),
                             checked = uiState.showSignatureDetails,
                             onCheckedChange = {
-                                viewModel.dispatch(InstallerSettingsAction.ChangeShowSignatureDetails(it))
+                                viewModel.dispatch(
+                                    InstallerSettingsAction.ChangeShowSignatureDetails(
+                                        it
+                                    )
+                                )
                             }
                         )
                     }
@@ -247,7 +245,13 @@ fun InstallerGlobalSettingsPage(
                             title = stringResource(R.string.config_detect_xposed_module),
                             description = stringResource(R.string.config_detect_xposed_module_desc),
                             checked = uiState.detectXposedModule,
-                            onCheckedChange = { viewModel.dispatch(InstallerSettingsAction.ChangeDetectXposedModule(it)) }
+                            onCheckedChange = {
+                                viewModel.dispatch(
+                                    InstallerSettingsAction.ChangeDetectXposedModule(
+                                        it
+                                    )
+                                )
+                            }
                         )
                     }
 
@@ -257,7 +261,13 @@ fun InstallerGlobalSettingsPage(
                             title = stringResource(R.string.config_quick_open_lsposed),
                             description = stringResource(R.string.config_quick_open_lsposed_desc),
                             checked = uiState.quickOpenLSPosed,
-                            onCheckedChange = { viewModel.dispatch(InstallerSettingsAction.ChangeQuickOpenLSPosed(it)) }
+                            onCheckedChange = {
+                                viewModel.dispatch(
+                                    InstallerSettingsAction.ChangeQuickOpenLSPosed(
+                                        it
+                                    )
+                                )
+                            }
                         )
                     }
                 }
@@ -275,7 +285,13 @@ fun InstallerGlobalSettingsPage(
                                 title = stringResource(id = R.string.installer_show_oem_special),
                                 description = stringResource(id = R.string.installer_show_oem_special_desc),
                                 checked = uiState.showOPPOSpecial,
-                                onCheckedChange = { viewModel.dispatch(InstallerSettingsAction.ChangeShowOPPOSpecial(it)) }
+                                onCheckedChange = {
+                                    viewModel.dispatch(
+                                        InstallerSettingsAction.ChangeShowOPPOSpecial(
+                                            it
+                                        )
+                                    )
+                                }
                             )
                         }
                     }
@@ -293,10 +309,27 @@ fun InstallerGlobalSettingsPage(
                         ManagedPackagesWidget(
                             noContentTitle = stringResource(R.string.config_no_preset_install_sources),
                             packages = uiState.managedInstallerPackages,
-                            onAddPackage = { viewModel.dispatch(InstallerSettingsAction.AddManagedInstallerPackage(it)) },
-                            onRemovePackage = { viewModel.dispatch(InstallerSettingsAction.RemoveManagedInstallerPackage(it)) },
+                            onAddPackage = {
+                                viewModel.dispatch(
+                                    InstallerSettingsAction.AddManagedInstallerPackage(
+                                        it
+                                    )
+                                )
+                            },
+                            onRemovePackage = {
+                                viewModel.dispatch(
+                                    InstallerSettingsAction.RemoveManagedInstallerPackage(
+                                        it
+                                    )
+                                )
+                            },
                             onMovePackage = { fromIndex, toIndex ->
-                                viewModel.dispatch(InstallerSettingsAction.MoveManagedInstallerPackage(fromIndex, toIndex))
+                                viewModel.dispatch(
+                                    InstallerSettingsAction.MoveManagedInstallerPackage(
+                                        fromIndex,
+                                        toIndex
+                                    )
+                                )
                             }
                         )
                     }
@@ -313,10 +346,27 @@ fun InstallerGlobalSettingsPage(
                         ManagedPackagesWidget(
                             noContentTitle = stringResource(R.string.config_no_managed_blacklist),
                             packages = uiState.managedBlacklistPackages,
-                            onAddPackage = { viewModel.dispatch(InstallerSettingsAction.AddManagedBlacklistPackage(it)) },
-                            onRemovePackage = { viewModel.dispatch(InstallerSettingsAction.RemoveManagedBlacklistPackage(it)) },
+                            onAddPackage = {
+                                viewModel.dispatch(
+                                    InstallerSettingsAction.AddManagedBlacklistPackage(
+                                        it
+                                    )
+                                )
+                            },
+                            onRemovePackage = {
+                                viewModel.dispatch(
+                                    InstallerSettingsAction.RemoveManagedBlacklistPackage(
+                                        it
+                                    )
+                                )
+                            },
                             onMovePackage = { fromIndex, toIndex ->
-                                viewModel.dispatch(InstallerSettingsAction.MoveManagedBlacklistPackage(fromIndex, toIndex))
+                                viewModel.dispatch(
+                                    InstallerSettingsAction.MoveManagedBlacklistPackage(
+                                        fromIndex,
+                                        toIndex
+                                    )
+                                )
                             }
                         )
                     }
@@ -333,10 +383,27 @@ fun InstallerGlobalSettingsPage(
                         ManagedUidsWidget(
                             noContentTitle = stringResource(R.string.config_no_managed_shared_user_id_blacklist),
                             uids = uiState.managedSharedUserIdBlacklist,
-                            onAddUid = { viewModel.dispatch(InstallerSettingsAction.AddManagedSharedUserIdBlacklist(it)) },
-                            onRemoveUid = { viewModel.dispatch(InstallerSettingsAction.RemoveManagedSharedUserIdBlacklist(it)) },
+                            onAddUid = {
+                                viewModel.dispatch(
+                                    InstallerSettingsAction.AddManagedSharedUserIdBlacklist(
+                                        it
+                                    )
+                                )
+                            },
+                            onRemoveUid = {
+                                viewModel.dispatch(
+                                    InstallerSettingsAction.RemoveManagedSharedUserIdBlacklist(
+                                        it
+                                    )
+                                )
+                            },
                             onMoveUid = { from, to ->
-                                viewModel.dispatch(InstallerSettingsAction.MoveManagedSharedUserIdBlacklist(from, to))
+                                viewModel.dispatch(
+                                    InstallerSettingsAction.MoveManagedSharedUserIdBlacklist(
+                                        from,
+                                        to
+                                    )
+                                )
                             }
                         )
                     }
@@ -348,7 +415,13 @@ fun InstallerGlobalSettingsPage(
                             packages = uiState.managedSharedUserIdExemptedPackages,
                             infoText = stringResource(R.string.config_no_managed_shared_user_id_exempted_packages),
                             isInfoVisible = uiState.managedSharedUserIdExemptedPackages.isNotEmpty(),
-                            onAddPackage = { viewModel.dispatch(InstallerSettingsAction.AddManagedSharedUserIdExemptedPackages(it)) },
+                            onAddPackage = {
+                                viewModel.dispatch(
+                                    InstallerSettingsAction.AddManagedSharedUserIdExemptedPackages(
+                                        it
+                                    )
+                                )
+                            },
                             onRemovePackage = {
                                 viewModel.dispatch(
                                     InstallerSettingsAction.RemoveManagedSharedUserIdExemptedPackages(
@@ -357,14 +430,18 @@ fun InstallerGlobalSettingsPage(
                                 )
                             },
                             onMovePackage = { fromIndex, toIndex ->
-                                viewModel.dispatch(InstallerSettingsAction.MoveManagedSharedUserIdExemptedPackages(fromIndex, toIndex))
+                                viewModel.dispatch(
+                                    InstallerSettingsAction.MoveManagedSharedUserIdExemptedPackages(
+                                        fromIndex,
+                                        toIndex
+                                    )
+                                )
                             }
                         )
                     }
                 }
             }
 
-            item { Spacer(Modifier.navigationBarsPadding()) }
         }
     }
 }
@@ -459,7 +536,11 @@ private fun ManagedPackagesWidget(
                             .background(infoColor.copy(alpha = 0.1f))
                             .padding(horizontal = 12.dp, vertical = 6.dp)
                     ) {
-                        Text(text = infoText ?: "", color = infoColor, style = MaterialTheme.typography.labelMedium)
+                        Text(
+                            text = infoText ?: "",
+                            color = infoColor,
+                            style = MaterialTheme.typography.labelMedium
+                        )
                     }
                 }
                 Spacer(modifier = Modifier.weight(1f))

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/installer/authorizer/AuthorizerCustPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/installer/authorizer/AuthorizerCustPage.kt
@@ -5,19 +5,11 @@
 package com.rosan.installer.ui.page.main.settings.preferred.installer.authorizer
 
 import android.os.Build
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.add
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -33,7 +25,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -71,9 +62,6 @@ fun AuthorizerCustPage(
         topAppBarState.heightOffset = topAppBarState.heightOffsetLimit
     }
 
-    val layoutDirection = LocalLayoutDirection.current
-    val horizontalSafeInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal).asPaddingValues()
-
     val backdrop = rememberMaterial3BlurBackdrop(useBlur)
 
     Scaffold(
@@ -107,12 +95,7 @@ fun AuthorizerCustPage(
             modifier = Modifier
                 .fillMaxSize()
                 .then(backdrop?.let { Modifier.layerBackdrop(it) } ?: Modifier),
-            contentPadding = PaddingValues(
-                start = horizontalSafeInsets.calculateStartPadding(layoutDirection),
-                top = paddingValues.calculateTopPadding(),
-                end = horizontalSafeInsets.calculateEndPadding(layoutDirection),
-                bottom = paddingValues.calculateBottomPadding()
-            )
+            contentPadding = paddingValues
         ) {
             item {
                 SegmentedColumn(
@@ -125,7 +108,13 @@ fun AuthorizerCustPage(
                             title = stringResource(R.string.config_always_use_root_in_system),
                             description = stringResource(R.string.config_always_use_root_in_system_desc),
                             checked = uiState.alwaysUseRootInSystem,
-                            onCheckedChange = { viewModel.dispatch(AuthorizerCustAction.ChangeAlwaysUseRootInSystem(it)) }
+                            onCheckedChange = {
+                                viewModel.dispatch(
+                                    AuthorizerCustAction.ChangeAlwaysUseRootInSystem(
+                                        it
+                                    )
+                                )
+                            }
                         )
                     }
 
@@ -136,7 +125,13 @@ fun AuthorizerCustPage(
                                 title = stringResource(R.string.lab_install_without_user_action),
                                 description = stringResource(R.string.lab_install_without_user_action_desc),
                                 checked = uiState.allowInstallWithoutUserAction,
-                                onCheckedChange = { viewModel.dispatch(AuthorizerCustAction.ChangeAllowInstallWithoutUserAction(it)) }
+                                onCheckedChange = {
+                                    viewModel.dispatch(
+                                        AuthorizerCustAction.ChangeAllowInstallWithoutUserAction(
+                                            it
+                                        )
+                                    )
+                                }
                             )
                         }
                     }
@@ -158,7 +153,11 @@ fun AuthorizerCustPage(
                                 endInt = 10,
                                 stepSize = 1,
                                 onValueChange = {
-                                    viewModel.dispatch(AuthorizerCustAction.ChangeCloseSessionCountDown(it))
+                                    viewModel.dispatch(
+                                        AuthorizerCustAction.ChangeCloseSessionCountDown(
+                                            it
+                                        )
+                                    )
                                 }
                             )
                         }
@@ -166,7 +165,6 @@ fun AuthorizerCustPage(
                 }
             }
 
-            item { Spacer(Modifier.navigationBarsPadding()) }
         }
     }
 }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/installer/dialog/DialogSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/installer/dialog/DialogSettingsPage.kt
@@ -4,19 +4,11 @@
 
 package com.rosan.installer.ui.page.main.settings.preferred.installer.dialog
 
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.add
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -32,7 +24,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -63,9 +54,6 @@ fun DialogSettingsPage(
     LaunchedEffect(Unit) {
         topAppBarState.heightOffset = topAppBarState.heightOffsetLimit
     }
-
-    val layoutDirection = LocalLayoutDirection.current
-    val horizontalSafeInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal).asPaddingValues()
 
     val backdrop = rememberMaterial3BlurBackdrop(useBlur)
 
@@ -100,12 +88,7 @@ fun DialogSettingsPage(
             modifier = Modifier
                 .fillMaxSize()
                 .then(backdrop?.let { Modifier.layerBackdrop(it) } ?: Modifier),
-            contentPadding = PaddingValues(
-                start = horizontalSafeInsets.calculateStartPadding(layoutDirection),
-                top = paddingValues.calculateTopPadding(),
-                end = horizontalSafeInsets.calculateEndPadding(layoutDirection),
-                bottom = paddingValues.calculateBottomPadding()
-            )
+            contentPadding = paddingValues
         ) {
             item {
                 SegmentedColumn(
@@ -119,7 +102,11 @@ fun DialogSettingsPage(
                             description = stringResource(id = R.string.version_compare_in_single_line_desc),
                             checked = uiState.versionCompareInSingleLine,
                             onCheckedChange = {
-                                viewModel.dispatch(DialogSettingsAction.ChangeVersionCompareInSingleLine(it))
+                                viewModel.dispatch(
+                                    DialogSettingsAction.ChangeVersionCompareInSingleLine(
+                                        it
+                                    )
+                                )
                             }
                         )
                     }
@@ -132,7 +119,11 @@ fun DialogSettingsPage(
                             description = stringResource(id = R.string.sdk_compare_in_multi_line_desc),
                             checked = uiState.sdkCompareInMultiLine,
                             onCheckedChange = {
-                                viewModel.dispatch(DialogSettingsAction.ChangeSdkCompareInMultiLine(it))
+                                viewModel.dispatch(
+                                    DialogSettingsAction.ChangeSdkCompareInMultiLine(
+                                        it
+                                    )
+                                )
                             }
                         )
                     }
@@ -145,7 +136,11 @@ fun DialogSettingsPage(
                             description = stringResource(id = R.string.show_dialog_install_extended_menu_desc),
                             checked = uiState.showDialogInstallExtendedMenu,
                             onCheckedChange = {
-                                viewModel.dispatch(DialogSettingsAction.ChangeShowDialogInstallExtendedMenu(it))
+                                viewModel.dispatch(
+                                    DialogSettingsAction.ChangeShowDialogInstallExtendedMenu(
+                                        it
+                                    )
+                                )
                             }
                         )
                     }
@@ -171,7 +166,11 @@ fun DialogSettingsPage(
                             description = stringResource(id = R.string.close_notification_immediately_on_dialog_dismiss),
                             checked = uiState.disableNotificationForDialogInstall,
                             onCheckedChange = {
-                                viewModel.dispatch(DialogSettingsAction.ChangeShowDisableNotification(it))
+                                viewModel.dispatch(
+                                    DialogSettingsAction.ChangeShowDisableNotification(
+                                        it
+                                    )
+                                )
                             }
                         )
                     }
@@ -203,7 +202,11 @@ fun DialogSettingsPage(
                             description = stringResource(id = R.string.long_click_background_install_desc),
                             checked = uiState.longClickBackgroundInstall,
                             onCheckedChange = {
-                                viewModel.dispatch(DialogSettingsAction.ChangeLongClickBackgroundInstall(it))
+                                viewModel.dispatch(
+                                    DialogSettingsAction.ChangeLongClickBackgroundInstall(
+                                        it
+                                    )
+                                )
                             }
                         )
                     }
@@ -228,7 +231,6 @@ fun DialogSettingsPage(
                 }
             }
 
-            item { Spacer(Modifier.navigationBarsPadding()) }
         }
     }
 }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/installer/notification/NotificationSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/installer/notification/NotificationSettingsPage.kt
@@ -5,19 +5,11 @@
 package com.rosan.installer.ui.page.main.settings.preferred.installer.notification
 
 import android.os.Build
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.add
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -34,7 +26,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -71,9 +62,6 @@ fun NotificationSettingsPage(
     LaunchedEffect(Unit) {
         topAppBarState.heightOffset = topAppBarState.heightOffsetLimit
     }
-
-    val layoutDirection = LocalLayoutDirection.current
-    val horizontalSafeInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal).asPaddingValues()
 
     val isModernEligible = Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA
     val isMiIslandSupported = capabilityProvider.isSupportMiIsland
@@ -133,12 +121,7 @@ fun NotificationSettingsPage(
             modifier = Modifier
                 .fillMaxSize()
                 .then(backdrop?.let { Modifier.layerBackdrop(it) } ?: Modifier),
-            contentPadding = PaddingValues(
-                start = horizontalSafeInsets.calculateStartPadding(layoutDirection),
-                top = paddingValues.calculateTopPadding(),
-                end = horizontalSafeInsets.calculateEndPadding(layoutDirection),
-                bottom = paddingValues.calculateBottomPadding()
-            )
+            contentPadding = paddingValues
         ) {
             item {
                 SegmentedColumn(
@@ -149,13 +132,19 @@ fun NotificationSettingsPage(
                         DropDownMenuWidget(
                             icon = AppIcons.Palette,
                             title = stringResource(R.string.notification_style),
-                            description = if (isStyleSelectionEnabled) styleNames[selectedIndex] else stringResource(R.string.notification_style_unsupported_desc),
+                            description = if (isStyleSelectionEnabled) styleNames[selectedIndex] else stringResource(
+                                R.string.notification_style_unsupported_desc
+                            ),
                             enabled = isStyleSelectionEnabled,
                             choice = selectedIndex,
                             data = styleNames,
                             onChoiceChange = { index ->
                                 val selectedStyle = styleOptions[index]
-                                viewModel.dispatch(NotificationSettingsAction.ChangeStyle(selectedStyle))
+                                viewModel.dispatch(
+                                    NotificationSettingsAction.ChangeStyle(
+                                        selectedStyle
+                                    )
+                                )
                             }
                         )
                     }
@@ -166,7 +155,11 @@ fun NotificationSettingsPage(
                             description = stringResource(id = R.string.lab_mi_island_bypass_restriction_desc),
                             checked = uiState.miIslandBypassRestriction,
                             onCheckedChange = {
-                                viewModel.dispatch(NotificationSettingsAction.ChangeMiIslandBypassRestriction(it))
+                                viewModel.dispatch(
+                                    NotificationSettingsAction.ChangeMiIslandBypassRestriction(
+                                        it
+                                    )
+                                )
                             }
                         )
                     }
@@ -180,7 +173,11 @@ fun NotificationSettingsPage(
                                 startInt = 50,
                                 endInt = 350,
                                 onValueChange = {
-                                    viewModel.dispatch(NotificationSettingsAction.ChangeMiIslandBlockingInterval(it))
+                                    viewModel.dispatch(
+                                        NotificationSettingsAction.ChangeMiIslandBlockingInterval(
+                                            it
+                                        )
+                                    )
                                 }
                             )
                         }
@@ -192,7 +189,11 @@ fun NotificationSettingsPage(
                             description = stringResource(id = R.string.lab_mi_island_outer_glow_desc),
                             checked = uiState.miIslandOuterGlow,
                             onCheckedChange = {
-                                viewModel.dispatch(NotificationSettingsAction.ChangeMiIslandOuterGlow(it))
+                                viewModel.dispatch(
+                                    NotificationSettingsAction.ChangeMiIslandOuterGlow(
+                                        it
+                                    )
+                                )
                             }
                         )
                     }
@@ -209,7 +210,11 @@ fun NotificationSettingsPage(
                             description = stringResource(id = R.string.change_notification_touch_behavior),
                             checked = uiState.showDialogOnPress,
                             onCheckedChange = {
-                                viewModel.dispatch(NotificationSettingsAction.ChangeShowDialogOnPress(it))
+                                viewModel.dispatch(
+                                    NotificationSettingsAction.ChangeShowDialogOnPress(
+                                        it
+                                    )
+                                )
                             }
                         )
                     }
@@ -218,14 +223,17 @@ fun NotificationSettingsPage(
                         AutoClearNotificationTimeWidget(
                             currentValue = uiState.successAutoClearSeconds,
                             onValueChange = { seconds ->
-                                viewModel.dispatch(NotificationSettingsAction.ChangeAutoClearSeconds(seconds))
+                                viewModel.dispatch(
+                                    NotificationSettingsAction.ChangeAutoClearSeconds(
+                                        seconds
+                                    )
+                                )
                             }
                         )
                     }
                 }
             }
 
-            item { Spacer(Modifier.navigationBarsPadding()) }
         }
     }
 }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/lab/LabPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/lab/LabPage.kt
@@ -6,21 +6,14 @@ package com.rosan.installer.ui.page.main.settings.preferred.lab
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.add
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
@@ -48,7 +41,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
@@ -123,13 +115,21 @@ fun LabPage(
             onDismiss = {
                 showCustomProxyDialog.value = false
                 if (uiState.customGithubProxyUrl.isEmpty())
-                    viewModel.dispatch(LabSettingsAction.LabChangeGithubUpdateChannel(GithubUpdateChannel.OFFICIAL))
+                    viewModel.dispatch(
+                        LabSettingsAction.LabChangeGithubUpdateChannel(
+                            GithubUpdateChannel.OFFICIAL
+                        )
+                    )
             },
             onConfirm = { url ->
                 showCustomProxyDialog.value = false
                 viewModel.dispatch(LabSettingsAction.LabChangeCustomGithubProxyUrl(url))
                 if (url.isEmpty())
-                    viewModel.dispatch(LabSettingsAction.LabChangeGithubUpdateChannel(GithubUpdateChannel.OFFICIAL))
+                    viewModel.dispatch(
+                        LabSettingsAction.LabChangeGithubUpdateChannel(
+                            GithubUpdateChannel.OFFICIAL
+                        )
+                    )
             }
         )
 
@@ -151,8 +151,6 @@ fun LabPage(
         )
     }
 
-    val layoutDirection = LocalLayoutDirection.current
-    val horizontalSafeInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal).asPaddingValues()
     val smartAuthorizerSummary = uiState.smartAuthorizerCandidates
         .filter { it.enabled }
         .joinToString("->") {
@@ -192,12 +190,7 @@ fun LabPage(
             modifier = Modifier
                 .fillMaxSize()
                 .then(backdrop?.let { Modifier.layerBackdrop(it) } ?: Modifier),
-            contentPadding = PaddingValues(
-                start = horizontalSafeInsets.calculateStartPadding(layoutDirection),
-                top = paddingValues.calculateTopPadding(),
-                end = horizontalSafeInsets.calculateEndPadding(layoutDirection),
-                bottom = paddingValues.calculateBottomPadding()
-            )
+            contentPadding = paddingValues
         ) {
             item { InfoTipCard(text = stringResource(R.string.lab_tip)) }
             item {
@@ -326,7 +319,6 @@ fun LabPage(
                         }
                     }
                 }
-            item { Spacer(Modifier.navigationBarsPadding()) }
         }
     }
 

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/theme/ThemeSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/theme/ThemeSettingsPage.kt
@@ -18,21 +18,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.add
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -61,7 +53,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -169,9 +160,6 @@ fun ThemeSettingsPage(
         }
     )
 
-    val layoutDirection = LocalLayoutDirection.current
-    val horizontalSafeInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal).asPaddingValues()
-
     val backdrop = rememberMaterial3BlurBackdrop(uiState.useBlur)
 
     Scaffold(
@@ -205,12 +193,7 @@ fun ThemeSettingsPage(
             modifier = Modifier
                 .fillMaxSize()
                 .then(backdrop?.let { Modifier.layerBackdrop(it) } ?: Modifier),
-            contentPadding = PaddingValues(
-                start = horizontalSafeInsets.calculateStartPadding(layoutDirection),
-                top = paddingValues.calculateTopPadding(),
-                end = horizontalSafeInsets.calculateEndPadding(layoutDirection),
-                bottom = paddingValues.calculateBottomPadding()
-            )
+            contentPadding = paddingValues
         ) {
             // --- Group 1: UI Style Selection ---
             item {
@@ -276,7 +259,13 @@ fun ThemeSettingsPage(
                                 title = stringResource(R.string.theme_settings_use_blur),
                                 description = stringResource(R.string.theme_settings_use_blur_desc),
                                 checked = uiState.useBlur,
-                                onCheckedChange = { viewModel.dispatch(ThemeSettingsAction.SetUseBlur(it)) }
+                                onCheckedChange = {
+                                    viewModel.dispatch(
+                                        ThemeSettingsAction.SetUseBlur(
+                                            it
+                                        )
+                                    )
+                                }
                             )
                         }
                     }
@@ -307,7 +296,13 @@ fun ThemeSettingsPage(
                             title = stringResource(R.string.theme_settings_dynamic_color),
                             description = stringResource(R.string.theme_settings_dynamic_color_desc),
                             checked = uiState.useDynamicColor,
-                            onCheckedChange = { viewModel.dispatch(ThemeSettingsAction.SetUseDynamicColor(it)) }
+                            onCheckedChange = {
+                                viewModel.dispatch(
+                                    ThemeSettingsAction.SetUseDynamicColor(
+                                        it
+                                    )
+                                )
+                            }
                         )
                     }
                     item {
@@ -316,7 +311,13 @@ fun ThemeSettingsPage(
                             title = stringResource(R.string.theme_settings_dynamic_color_follow_icon),
                             description = stringResource(R.string.theme_settings_dynamic_color_follow_icon_desc),
                             checked = uiState.useDynColorFollowPkgIcon,
-                            onCheckedChange = { viewModel.dispatch(ThemeSettingsAction.SetDynColorFollowPkgIcon(it)) }
+                            onCheckedChange = {
+                                viewModel.dispatch(
+                                    ThemeSettingsAction.SetDynColorFollowPkgIcon(
+                                        it
+                                    )
+                                )
+                            }
                         )
                     }
                     // Conditional item for Live Activity
@@ -342,10 +343,30 @@ fun ThemeSettingsPage(
             item {
                 AnimatedVisibility(
                     visible = !uiState.useDynamicColor || Build.VERSION.SDK_INT < Build.VERSION_CODES.S,
-                    enter = fadeIn(animationSpec = tween(durationMillis = 300, easing = FastOutSlowInEasing)) +
-                            expandVertically(animationSpec = tween(durationMillis = 400, easing = FastOutSlowInEasing)),
-                    exit = fadeOut(animationSpec = tween(durationMillis = 250, easing = FastOutSlowInEasing)) +
-                            shrinkVertically(animationSpec = tween(durationMillis = 350, easing = FastOutSlowInEasing))
+                    enter = fadeIn(
+                        animationSpec = tween(
+                            durationMillis = 300,
+                            easing = FastOutSlowInEasing
+                        )
+                    ) +
+                            expandVertically(
+                                animationSpec = tween(
+                                    durationMillis = 400,
+                                    easing = FastOutSlowInEasing
+                                )
+                            ),
+                    exit = fadeOut(
+                        animationSpec = tween(
+                            durationMillis = 250,
+                            easing = FastOutSlowInEasing
+                        )
+                    ) +
+                            shrinkVertically(
+                                animationSpec = tween(
+                                    durationMillis = 350,
+                                    easing = FastOutSlowInEasing
+                                )
+                            )
                 ) {
                     SegmentedColumn(
                         title = stringResource(R.string.theme_settings_theme_color)
@@ -358,7 +379,8 @@ fun ThemeSettingsPage(
                                         .padding(horizontal = 12.dp, vertical = 16.dp)
                                 ) {
                                     val itemMinWidth = 88.dp
-                                    val columns = (this.maxWidth / itemMinWidth).toInt().coerceAtLeast(1)
+                                    val columns =
+                                        (this.maxWidth / itemMinWidth).toInt().coerceAtLeast(1)
                                     val chunkedColors = uiState.availableColors.chunked(columns)
 
                                     Column(
@@ -379,13 +401,19 @@ fun ThemeSettingsPage(
                                                             rawColor = rawColor,
                                                             currentStyle = uiState.paletteStyle,
                                                             colorSpec = uiState.colorSpec,
-                                                            textStyle = MaterialTheme.typography.labelMedium.copy(fontSize = 13.sp),
+                                                            textStyle = MaterialTheme.typography.labelMedium.copy(
+                                                                fontSize = 13.sp
+                                                            ),
                                                             textColor = MaterialTheme.colorScheme.onSurface,
                                                             isSelected =
                                                                 uiState.seedColor == rawColor.color
-                                                                && !(uiState.useDynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S),
+                                                                        && !(uiState.useDynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S),
                                                         ) {
-                                                            viewModel.dispatch(ThemeSettingsAction.SetSeedColor(rawColor.color))
+                                                            viewModel.dispatch(
+                                                                ThemeSettingsAction.SetSeedColor(
+                                                                    rawColor.color
+                                                                )
+                                                            )
                                                         }
                                                     }
                                                 }
@@ -412,12 +440,18 @@ fun ThemeSettingsPage(
                     SegmentedColumn(
                         title = stringResource(R.string.theme_settings_predictive_back)
                     ) {
-                        item { PredictiveBackAnimationWidget(uiState) { showPredictiveBackAnimationDialog = true } }
+                        item {
+                            PredictiveBackAnimationWidget(uiState) {
+                                showPredictiveBackAnimationDialog = true
+                            }
+                        }
                         item(
                             animatedVisibility = uiState.predictiveBackAnimation == PredictiveBackAnimation.Scale ||
                                     uiState.predictiveBackAnimation == PredictiveBackAnimation.AOSP
                         ) {
-                            PredictiveBackAnimationDirectionWidget(uiState) { showPredictiveBackExitDirectionDialog = true }
+                            PredictiveBackAnimationDirectionWidget(uiState) {
+                                showPredictiveBackExitDirectionDialog = true
+                            }
                         }
                     }
                 }
@@ -434,7 +468,13 @@ fun ThemeSettingsPage(
                             title = stringResource(R.string.theme_settings_prefer_system_icon),
                             description = stringResource(R.string.theme_settings_prefer_system_icon_desc),
                             checked = uiState.preferSystemIcon,
-                            onCheckedChange = { viewModel.dispatch(ThemeSettingsAction.ChangePreferSystemIcon(it)) }
+                            onCheckedChange = {
+                                viewModel.dispatch(
+                                    ThemeSettingsAction.ChangePreferSystemIcon(
+                                        it
+                                    )
+                                )
+                            }
                         )
                     }
                 }
@@ -455,7 +495,11 @@ fun ThemeSettingsPage(
                                 if (newCheckedState) {
                                     showHideLauncherIconDialog = true
                                 } else {
-                                    viewModel.dispatch(ThemeSettingsAction.ChangeShowLauncherIcon(true))
+                                    viewModel.dispatch(
+                                        ThemeSettingsAction.ChangeShowLauncherIcon(
+                                            true
+                                        )
+                                    )
                                 }
                             }
                         )
@@ -463,7 +507,6 @@ fun ThemeSettingsPage(
                 }
             }
 
-            item { Spacer(Modifier.navigationBarsPadding()) }
         }
     }
 }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/uninstaller/UninstallerGlobalSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/uninstaller/UninstallerGlobalSettingsPage.kt
@@ -7,19 +7,11 @@ import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
 import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_WEAK
 import androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.add
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -39,11 +31,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.rosan.installer.R
+import com.rosan.installer.core.bitmask.hasFlag
 import com.rosan.installer.domain.engine.model.install.UninstallFlags
 import com.rosan.installer.ui.activity.UninstallerActivity
 import com.rosan.installer.ui.icons.AppIcons
@@ -57,7 +49,6 @@ import com.rosan.installer.ui.page.main.widget.setting.SwitchWidget
 import com.rosan.installer.ui.theme.getMaterial3AppBarColor
 import com.rosan.installer.ui.theme.installerMaterial3BlurEffect
 import com.rosan.installer.ui.theme.rememberMaterial3BlurBackdrop
-import com.rosan.installer.core.bitmask.hasFlag
 import com.rosan.installer.util.toast
 import org.koin.androidx.compose.koinViewModel
 import top.yukonga.miuix.kmp.blur.layerBackdrop
@@ -100,9 +91,6 @@ fun UninstallerGlobalSettingsPage(
             }
         )
 
-    val layoutDirection = LocalLayoutDirection.current
-    val horizontalSafeInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal).asPaddingValues()
-
     val backdrop = rememberMaterial3BlurBackdrop(useBlur)
 
     Scaffold(
@@ -136,12 +124,7 @@ fun UninstallerGlobalSettingsPage(
             modifier = Modifier
                 .fillMaxSize()
                 .then(backdrop?.let { Modifier.layerBackdrop(it) } ?: Modifier),
-            contentPadding = PaddingValues(
-                start = horizontalSafeInsets.calculateStartPadding(layoutDirection),
-                top = paddingValues.calculateTopPadding(),
-                end = horizontalSafeInsets.calculateEndPadding(layoutDirection),
-                bottom = paddingValues.calculateBottomPadding()
-            )
+            contentPadding = paddingValues
         ) {
             item { InfoTipCard(text = stringResource(R.string.uninstall_authorizer_tip)) }
             // --- Group 1: Global Settings ---
@@ -156,7 +139,12 @@ fun UninstallerGlobalSettingsPage(
                             description = stringResource(id = R.string.uninstall_keep_data_desc),
                             checked = uiState.uninstallFlags.hasFlag(UninstallFlags.DELETE_KEEP_DATA),
                             onCheckedChange = {
-                                viewModel.dispatch(UninstallerSettingsAction.ToggleGlobalUninstallFlag(UninstallFlags.DELETE_KEEP_DATA, it))
+                                viewModel.dispatch(
+                                    UninstallerSettingsAction.ToggleGlobalUninstallFlag(
+                                        UninstallFlags.DELETE_KEEP_DATA,
+                                        it
+                                    )
+                                )
                             }
                         )
                     }
@@ -167,7 +155,12 @@ fun UninstallerGlobalSettingsPage(
                             description = stringResource(id = R.string.uninstall_all_users_desc),
                             checked = uiState.uninstallFlags.hasFlag(UninstallFlags.DELETE_ALL_USERS),
                             onCheckedChange = {
-                                viewModel.dispatch(UninstallerSettingsAction.ToggleGlobalUninstallFlag(UninstallFlags.DELETE_ALL_USERS, it))
+                                viewModel.dispatch(
+                                    UninstallerSettingsAction.ToggleGlobalUninstallFlag(
+                                        UninstallFlags.DELETE_ALL_USERS,
+                                        it
+                                    )
+                                )
                             }
                         )
                     }
@@ -221,7 +214,6 @@ fun UninstallerGlobalSettingsPage(
                 }
             }
 
-            item { Spacer(Modifier.navigationBarsPadding()) }
         }
     }
 }


### PR DESCRIPTION
改进了设置页面的 Window Insets 传递机制，并修复了各页面底部的双重导航栏边距的问题

- 新：
<img width="1280" height="2772" alt="Screenshot_2026-06-24-19-47-25-630_com rosan installer x revived" src="https://github.com/user-attachments/assets/17ea057e-6ac4-49d5-a198-8eceeca38fb3" />
<img width="1280" height="2772" alt="Screenshot_2026-06-24-19-47-32-836_com rosan installer x revived" src="https://github.com/user-attachments/assets/1617f24c-4cc0-4711-b9eb-9d8b5665561c" />


- 旧：
<img width="1280" height="2772" alt="Screenshot_2026-06-24-19-44-20-732_com rosan installer x revived" src="https://github.com/user-attachments/assets/d8aeac40-62ce-461e-99f9-b6b1aa9aab86" />
<img width="1280" height="2772" alt="Screenshot_2026-06-24-19-44-48-344_com rosan installer x revived" src="https://github.com/user-attachments/assets/7665eb45-1ecb-46da-9e44-d577ccce55d0" />
