### PR TITLE
ci: trigger preview workflows on Gradle module changes

### DIFF
--- a/.github/workflows/auto-preview-dev.yml
+++ b/.github/workflows/auto-preview-dev.yml
@@ -8,6 +8,10 @@ on:
       - 'renovate/**'
     paths:
       - 'app/**'
+      - 'app-process/**'
+      - 'hidden-api/**'
+      - 'baselineprofile/**'
+      - 'build-plugins/**'
       - 'build.gradle.kts'
       - 'settings.gradle.kts'
       - 'gradle.properties'

--- a/.github/workflows/auto-preview-release.yml
+++ b/.github/workflows/auto-preview-release.yml
@@ -6,6 +6,10 @@ on:
     # Only trigger on specific path changes
     paths:
       - 'app/**'
+      - 'app-process/**'
+      - 'hidden-api/**'
+      - 'baselineprofile/**'
+      - 'build-plugins/**'
       - 'build.gradle.kts'
       - 'settings.gradle.kts'
       - 'gradle.properties'


### PR DESCRIPTION
The paths filters in auto-preview-dev.yml and auto-preview-release.yml match only 'app/**', so a push whose changes are confined to one of the other Gradle modules triggers neither the dev artifact build nor the prerelease build.

All four are compiled into the APK:

  * app-process    implementation(project(":app-process"))
  * hidden-api     compileOnly(project(":hidden-api"))
  * baselineprofile "baselineProfile"(project(":baselineprofile"))
  * build-plugins  includeBuild, defines VERSION_CODE / TARGET_SDK

app-process is the notable one: it carries privileged installation behavior, so a change there can alter what the shipped APK does while neither workflow runs until an unrelated watched file happens to change.


Claude-Session: https://claude.ai/code/session_01W88XN3R2Z1XuNs658xuHxo