### PR TITLE
ci: add unit test stage and update build tasks

### DIFF
--- a/.github/workflows/auto-preview-dev.yml
+++ b/.github/workflows/auto-preview-dev.yml
@@ -1,4 +1,4 @@
-name: Dev Branch Build & Artifact
+name: Branch CI
 
 on:
   push:
@@ -16,6 +16,7 @@ on:
 
 jobs:
   pre_job:
+    name: Duplicate Check
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -78,7 +79,7 @@ jobs:
         run: ./gradlew testUnstableDebugUnitTest --no-configuration-cache
 
   build_and_upload_artifact:
-    name: Build APK
+    name: Build Unstable Release APK
     needs:
       - pre_job
       - unit_tests

--- a/.github/workflows/auto-preview-dev.yml
+++ b/.github/workflows/auto-preview-dev.yml
@@ -33,9 +33,56 @@ jobs:
           # Optional: ignore certain paths (usually handled in on.push.paths)
           do_not_skip: '[]'
 
-  build_and_upload_artifact:
+  unit_tests:
+    name: Unit Tests
     needs: pre_job
     # Run only if should_skip is not true and commit message does not contain [skip dev]
+    if: |
+      needs.pre_job.outputs.should_skip != 'true' &&
+      !contains(github.event.head_commit.message, '[skip dev]')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: '25'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          # Accept the terms of use to suppress the caching licensing warning
+          build-scan-terms-of-use-url: "https://gradle.com/help/legal-terms-of-use"
+          build-scan-terms-of-use-agree: "yes"
+          build-scan-publish: false
+          # Allow writing to cache for dev branch
+          cache-read-only: ${{ github.ref_name != 'dev' }}
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Run Unstable Debug Unit Tests
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew testUnstableDebugUnitTest --no-configuration-cache
+
+  build_and_upload_artifact:
+    name: Build APK
+    needs:
+      - pre_job
+      - unit_tests
+    # Build only after unit tests pass and the run is not skipped.
     if: |
       needs.pre_job.outputs.should_skip != 'true' &&
       !contains(github.event.head_commit.message, '[skip dev]')
@@ -67,7 +114,7 @@ jobs:
           build-scan-terms-of-use-url: "https://gradle.com/help/legal-terms-of-use"
           build-scan-terms-of-use-agree: "yes"
           build-scan-publish: false
-          # Allow writing to cache for dev branch
+          # Restore the cache populated by tests and update it on dev.
           cache-read-only: ${{ github.ref_name != 'dev' }}
           cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
@@ -95,7 +142,7 @@ jobs:
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew assembleUnstableRelease
+        run: ./gradlew assembleUnstableRelease --no-configuration-cache
 
       - name: Upload APK
         uses: actions/upload-artifact@v7

--- a/.github/workflows/auto-preview-release.yml
+++ b/.github/workflows/auto-preview-release.yml
@@ -1,4 +1,4 @@
-name: Automatic Alpha Pre-Release (Latest Only)
+name: Preview Release
 
 on:
   push:
@@ -25,6 +25,7 @@ on:
 
 jobs:
   build_and_prerelease:
+    name: Build and Publish Preview
     # Skip preview release for version bumps or explicitly skipped commits
     if: |
       !startsWith(github.event.head_commit.message, 'chore: bump version') &&

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   pre_job:
+    name: Duplicate Check
     # Do not skip if triggered by schedule, AND skip if the PR source branch is 'weblate-dev'
     if: github.event_name != 'schedule' && github.head_ref != 'weblate-dev'
     runs-on: ubuntu-latest
@@ -26,7 +27,7 @@ jobs:
           concurrent_skipping: 'never'
 
   analyze:
-    name: Analyze
+    name: Analyze Java/Kotlin
     # 依赖检查
     needs: pre_job
     # 如果是定时任务(schedule)直接跑，或者 skip 检查说不跳过才跑

--- a/.github/workflows/manual-stable-release.yml
+++ b/.github/workflows/manual-stable-release.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build_and_release:
+    name: Build Draft Release
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -12,7 +12,8 @@ permissions:
   packages: read # Required if you pull dependencies from GitHub Packages
 
 jobs:
-  build_for_pr:
+  unit_tests:
+    name: Unit Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -40,12 +41,49 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
-      - name: Build Preview Debug APK
+      - name: Run Unstable Debug Unit Tests
+        # Use the same application ID override as the APK build.
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew testUnstableDebugUnitTest --no-configuration-cache -PAPP_ID="com.rosan.installer.x.revived.test"
+
+  build_for_pr:
+    name: Build APK
+    needs: unit_tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: '25'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          build-scan-terms-of-use-url: "https://gradle.com/help/legal-terms-of-use"
+          build-scan-terms-of-use-agree: "yes"
+          build-scan-publish: false
+          # Keep read-only to prevent cache poisoning from PRs
+          cache-read-only: true
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build Unstable Debug APK
         # Use GITHUB_TOKEN only if strictly necessary for fetching packages
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew assemblePreviewDebug -PAPP_ID="com.rosan.installer.x.revived.test"
+        run: ./gradlew assembleUnstableDebug --no-configuration-cache -PAPP_ID="com.rosan.installer.x.revived.test"
 
       - name: Upload Debug APK
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -49,7 +49,7 @@ jobs:
         run: ./gradlew testUnstableDebugUnitTest --no-configuration-cache -PAPP_ID="com.rosan.installer.x.revived.test"
 
   build_for_pr:
-    name: Build Unstable Debug APK
+    name: Build Preview Debug APK
     needs: unit_tests
     runs-on: ubuntu-latest
 
@@ -78,12 +78,12 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
-      - name: Build Unstable Debug APK
+      - name: Build Preview Debug APK
         # Use GITHUB_TOKEN only if strictly necessary for fetching packages
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew assembleUnstableDebug --no-configuration-cache -PAPP_ID="com.rosan.installer.x.revived.test"
+        run: ./gradlew assemblePreviewDebug --no-configuration-cache -PAPP_ID="com.rosan.installer.x.revived.test"
 
       - name: Upload Debug APK
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,4 +1,4 @@
-name: PR Build and Test Check
+name: PR CI
 
 on:
   pull_request:
@@ -49,7 +49,7 @@ jobs:
         run: ./gradlew testUnstableDebugUnitTest --no-configuration-cache -PAPP_ID="com.rosan.installer.x.revived.test"
 
   build_for_pr:
-    name: Build APK
+    name: Build Unstable Debug APK
     needs: unit_tests
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
* Add `unit_tests` job using JDK 25 and gate APK assembly on success.
* Rename PR build task from `assemblePreviewDebug` to `assembleUnstableDebug`.
* Disable Gradle configuration cache for test and assembly tasks.