### PR TITLE
feat: add field-scoped history search to history page. 

### DIFF
--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryFormatters.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryFormatters.kt
@@ -5,6 +5,7 @@ package com.rosan.installer.ui.page.main.settings.history
 import androidx.annotation.StringRes
 import com.rosan.installer.R
 import com.rosan.installer.domain.history.model.InstallMethod
+import com.rosan.installer.domain.history.model.OperationHistoryModel
 import com.rosan.installer.domain.history.model.OperationStatus
 import com.rosan.installer.domain.history.model.OperationType
 import com.rosan.installer.domain.history.model.VersionChange
@@ -38,6 +39,9 @@ fun InstallMethod.labelRes(): Int = when (this) {
     InstallMethod.PACKAGE_MANAGER -> R.string.history_method_package_manager
     InstallMethod.SESSION -> R.string.history_method_session
 }
+
+fun OperationHistoryModel.hasPackageManagerDetails(): Boolean =
+    installMethod == InstallMethod.PACKAGE_MANAGER
 
 fun Long.formatHistoryTime(): String =
     DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT).format(Date(this))

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryPage.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
@@ -20,7 +22,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.lazy.LazyColumn
@@ -118,6 +122,11 @@ fun HistoryPage(
     ) {
         filterHistoryRecords(state.records, state.searchField, state.searchQuery, searchTexts)
     }
+    val hasNoSearchResults = hasNoHistorySearchResults(
+        records = state.records,
+        query = state.searchQuery,
+        visibleRecords = visibleRecords
+    )
 
     var selectedRecord by remember { mutableStateOf<OperationHistoryModel?>(null) }
     var showClearConfirmDialog by remember { mutableStateOf(false) }
@@ -238,16 +247,17 @@ fun HistoryPage(
                     if (visibleRecords.isEmpty()) {
                         item {
                             EmptyHistory(
-                                title = if (state.records.isNotEmpty() && state.searchQuery.isNotBlank()) {
+                                title = if (hasNoSearchResults) {
                                     stringResource(R.string.history_search_empty_title)
                                 } else {
                                     stringResource(R.string.history_empty_title)
                                 },
-                                description = if (state.records.isNotEmpty() && state.searchQuery.isNotBlank()) {
+                                description = if (hasNoSearchResults) {
                                     stringResource(R.string.history_search_empty_desc)
                                 } else {
                                     stringResource(R.string.history_empty_desc)
                                 },
+                                alignTop = hasNoSearchResults,
                                 modifier = Modifier
                                     .fillParentMaxSize()
                                     .padding(horizontal = 8.dp)
@@ -337,6 +347,10 @@ private fun HistorySearchControls(
     var expanded by remember { mutableStateOf(false) }
     val menuScrollState = rememberScrollState()
     val fields = HistorySearchField.entries
+    val horizontalSafeInsets = WindowInsets.safeDrawing
+        .only(WindowInsetsSides.Horizontal)
+        .asPaddingValues()
+    val layoutDirection = LocalLayoutDirection.current
 
     LaunchedEffect(Unit) {
         searchFocusRequester.requestFocus()
@@ -345,7 +359,10 @@ private fun HistorySearchControls(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp)
+            .padding(
+                start = 16.dp + horizontalSafeInsets.calculateStartPadding(layoutDirection),
+                end = 16.dp + horizontalSafeInsets.calculateEndPadding(layoutDirection)
+            )
             .padding(bottom = 8.dp)
     ) {
         ExposedDropdownMenuBox(
@@ -414,11 +431,12 @@ private fun HistorySearchControls(
 private fun EmptyHistory(
     title: String,
     description: String,
+    alignTop: Boolean,
     modifier: Modifier = Modifier
 ) {
     Column(
         modifier = modifier,
-        verticalArrangement = Arrangement.Top
+        verticalArrangement = if (alignTop) Arrangement.Top else Arrangement.Center
     ) {
         Text(
             text = title,

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryPage.kt
@@ -3,7 +3,9 @@
 package com.rosan.installer.ui.page.main.settings.history
 
 import android.content.ClipData
+import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -16,6 +18,7 @@ import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -26,13 +29,19 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ContainedLoadingIndicator
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.ExposedDropdownMenu
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
@@ -40,6 +49,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -48,6 +58,9 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
@@ -66,6 +79,9 @@ import com.rosan.installer.domain.history.model.OperationHistoryModel
 import com.rosan.installer.domain.history.model.OperationStatus
 import com.rosan.installer.domain.settings.model.config.Authorizer
 import com.rosan.installer.ui.icons.AppIcons
+import com.rosan.installer.ui.page.main.settings.history.HistorySearchField
+import com.rosan.installer.ui.page.main.settings.history.filterHistoryRecords
+import com.rosan.installer.ui.page.main.settings.history.rememberHistorySearchTexts
 import com.rosan.installer.ui.theme.bottomShape
 import com.rosan.installer.ui.theme.getMaterial3AppBarColor
 import com.rosan.installer.ui.theme.installerMaterial3BlurEffect
@@ -92,9 +108,20 @@ fun HistoryPage(
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(topAppBarState)
     val layoutDirection = LocalLayoutDirection.current
     val backdrop = rememberMaterial3BlurBackdrop(useBlur)
+    val searchTexts = rememberHistorySearchTexts(state.isSystemApp)
+    val visibleRecords = remember(
+        state.records,
+        state.searchQuery,
+        state.searchField,
+        searchTexts
+    ) {
+        filterHistoryRecords(state.records, state.searchField, state.searchQuery, searchTexts)
+    }
 
     var selectedRecord by remember { mutableStateOf<OperationHistoryModel?>(null) }
     var showClearConfirmDialog by remember { mutableStateOf(false) }
+    var searchBarActivated by remember { mutableStateOf(false) }
+    val searchFocusRequester = remember { FocusRequester() }
     val sheetState = rememberBottomSheetState(
         initialValue = SheetValue.Hidden,
         enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded)
@@ -106,32 +133,60 @@ fun HistoryPage(
             .fillMaxSize(),
         containerColor = MaterialTheme.colorScheme.surfaceContainer,
         topBar = {
-            LargeFlexibleTopAppBar(
-                modifier = Modifier.installerMaterial3BlurEffect(backdrop),
-                title = {
-                    Text(
-                        text = title,
-                        modifier = Modifier.padding(start = 12.dp)
-                    )
-                },
-                actions = {
-                    IconButton(
-                        enabled = state.records.isNotEmpty(),
-                        onClick = { showClearConfirmDialog = true }
-                    ) {
-                        Icon(
-                            imageVector = AppIcons.Delete,
-                            contentDescription = stringResource(R.string.history_clear)
+            Column(
+                modifier = Modifier
+                    .installerMaterial3BlurEffect(backdrop)
+                    .background(backdrop.getMaterial3AppBarColor())
+            ) {
+                LargeFlexibleTopAppBar(
+                    title = {
+                        Text(
+                            text = title,
+                            modifier = Modifier.padding(start = 12.dp)
                         )
-                    }
-                },
-                scrollBehavior = scrollBehavior,
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = backdrop.getMaterial3AppBarColor(),
-                    titleContentColor = MaterialTheme.colorScheme.onBackground,
-                    scrolledContainerColor = backdrop.getMaterial3AppBarColor()
+                    },
+                    actions = {
+                        if (!searchBarActivated) {
+                            IconButton(onClick = { searchBarActivated = true }) {
+                                Icon(
+                                    imageVector = AppIcons.Search,
+                                    contentDescription = stringResource(R.string.search)
+                                )
+                            }
+                        }
+                        IconButton(
+                            enabled = state.records.isNotEmpty(),
+                            onClick = { showClearConfirmDialog = true }
+                        ) {
+                            Icon(
+                                imageVector = AppIcons.Delete,
+                                contentDescription = stringResource(R.string.history_clear)
+                            )
+                        }
+                    },
+                    scrollBehavior = scrollBehavior,
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = Color.Transparent,
+                        titleContentColor = MaterialTheme.colorScheme.onBackground,
+                        scrolledContainerColor = Color.Transparent
+                    )
                 )
-            )
+
+                if (searchBarActivated) {
+                    HistorySearchControls(
+                        state = state,
+                        searchFocusRequester = searchFocusRequester,
+                        onClose = {
+                            searchBarActivated = false
+                            viewModel.dispatch(HistoryViewAction.Search(""))
+                            viewModel.dispatch(
+                                HistoryViewAction.SelectSearchField(HistorySearchField.ALL)
+                            )
+                        },
+                        dispatch = viewModel::dispatch,
+                    )
+                }
+            }
         }
     ) { paddingValues ->
         Box(modifier = Modifier.fillMaxSize()) {
@@ -176,9 +231,19 @@ fun HistoryPage(
                     ),
                     verticalArrangement = Arrangement.spacedBy(2.dp)
                 ) {
-                    if (state.records.isEmpty()) {
+                    if (visibleRecords.isEmpty()) {
                         item {
                             EmptyHistory(
+                                title = if (state.records.isNotEmpty() && state.searchQuery.isNotBlank()) {
+                                    stringResource(R.string.history_search_empty_title)
+                                } else {
+                                    stringResource(R.string.history_empty_title)
+                                },
+                                description = if (state.records.isNotEmpty() && state.searchQuery.isNotBlank()) {
+                                    stringResource(R.string.history_search_empty_desc)
+                                } else {
+                                    stringResource(R.string.history_empty_desc)
+                                },
                                 modifier = Modifier
                                     .fillParentMaxSize()
                                     .padding(horizontal = 8.dp)
@@ -186,14 +251,14 @@ fun HistoryPage(
                         }
                     } else {
                         itemsIndexed(
-                            items = state.records,
+                            items = visibleRecords,
                             key = { _, record -> record.id },
                             contentType = { _, _ -> "history_record" }
                         ) { index, record ->
                             val shape = when {
-                                state.records.size == 1 -> singleShape
+                                visibleRecords.size == 1 -> singleShape
                                 index == 0 -> topShape
-                                index == state.records.lastIndex -> bottomShape
+                                index == visibleRecords.lastIndex -> bottomShape
                                 else -> middleShape
                             }
 
@@ -258,19 +323,107 @@ fun HistoryPage(
 }
 
 @Composable
-private fun EmptyHistory(modifier: Modifier = Modifier) {
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+private fun HistorySearchControls(
+    state: HistoryViewState,
+    searchFocusRequester: FocusRequester,
+    onClose: () -> Unit,
+    dispatch: (HistoryViewAction) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val menuScrollState = rememberScrollState()
+    val fields = HistorySearchField.entries
+
+    LaunchedEffect(Unit) {
+        searchFocusRequester.requestFocus()
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .padding(bottom = 8.dp)
+    ) {
+        ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = { expanded = !expanded }
+        ) {
+            OutlinedTextField(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
+                value = stringResource(state.searchField.labelRes()),
+                onValueChange = {},
+                readOnly = true,
+                singleLine = true,
+                label = { Text(stringResource(R.string.history_search_scope)) },
+                trailingIcon = {
+                    ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+                }
+            )
+            ExposedDropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+                modifier = Modifier.heightIn(max = 360.dp),
+                scrollState = menuScrollState
+            ) {
+                fields.forEach { field ->
+                    DropdownMenuItem(
+                        text = { Text(stringResource(field.labelRes())) },
+                        onClick = {
+                            dispatch(HistoryViewAction.SelectSearchField(field))
+                            expanded = false
+                        }
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+        OutlinedTextField(
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(searchFocusRequester),
+            value = state.searchQuery,
+            onValueChange = { dispatch(HistoryViewAction.Search(it)) },
+            singleLine = true,
+            placeholder = { Text(stringResource(R.string.search)) },
+            leadingIcon = {
+                Icon(
+                    imageVector = AppIcons.Search,
+                    contentDescription = stringResource(R.string.search)
+                )
+            },
+            trailingIcon = {
+                IconButton(onClick = onClose) {
+                    Icon(
+                        imageVector = AppIcons.Close,
+                        contentDescription = stringResource(R.string.close)
+                    )
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun EmptyHistory(
+    title: String,
+    description: String,
+    modifier: Modifier = Modifier
+) {
     Column(
         modifier = modifier,
-        verticalArrangement = Arrangement.Center
+        verticalArrangement = Arrangement.Top
     ) {
         Text(
-            text = stringResource(R.string.history_empty_title),
+            text = title,
             style = MaterialTheme.typography.headlineSmall,
             color = MaterialTheme.colorScheme.onSurface
         )
         Spacer(modifier = Modifier.padding(top = 8.dp))
         Text(
-            text = stringResource(R.string.history_empty_desc),
+            text = description,
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryPage.kt
@@ -55,6 +55,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -120,7 +121,10 @@ fun HistoryPage(
 
     var selectedRecord by remember { mutableStateOf<OperationHistoryModel?>(null) }
     var showClearConfirmDialog by remember { mutableStateOf(false) }
-    var searchBarActivated by remember { mutableStateOf(false) }
+    var searchBarActivated by rememberSaveable { mutableStateOf(false) }
+    val hasSearchState =
+        state.searchQuery.isNotBlank() || state.searchField != HistorySearchField.ALL
+    val searchBarVisible = searchBarActivated || hasSearchState
     val searchFocusRequester = remember { FocusRequester() }
     val sheetState = rememberBottomSheetState(
         initialValue = SheetValue.Hidden,
@@ -146,7 +150,7 @@ fun HistoryPage(
                         )
                     },
                     actions = {
-                        if (!searchBarActivated) {
+                        if (!searchBarVisible) {
                             IconButton(onClick = { searchBarActivated = true }) {
                                 Icon(
                                     imageVector = AppIcons.Search,
@@ -172,7 +176,7 @@ fun HistoryPage(
                     )
                 )
 
-                if (searchBarActivated) {
+                if (searchBarVisible) {
                     HistorySearchControls(
                         state = state,
                         searchFocusRequester = searchFocusRequester,

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryPage.kt
@@ -84,9 +84,8 @@ import com.rosan.installer.domain.history.model.OperationHistoryModel
 import com.rosan.installer.domain.history.model.OperationStatus
 import com.rosan.installer.domain.settings.model.config.Authorizer
 import com.rosan.installer.ui.icons.AppIcons
-import com.rosan.installer.ui.page.main.settings.history.HistorySearchField
-import com.rosan.installer.ui.page.main.settings.history.filterHistoryRecords
 import com.rosan.installer.ui.page.main.settings.history.rememberHistorySearchTexts
+import com.rosan.installer.ui.page.main.settings.history.resolveHistorySearchResult
 import com.rosan.installer.ui.theme.bottomShape
 import com.rosan.installer.ui.theme.getMaterial3AppBarColor
 import com.rosan.installer.ui.theme.installerMaterial3BlurEffect
@@ -114,26 +113,16 @@ fun HistoryPage(
     val layoutDirection = LocalLayoutDirection.current
     val backdrop = rememberMaterial3BlurBackdrop(useBlur)
     val searchTexts = rememberHistorySearchTexts(state.isSystemApp)
-    val visibleRecords = remember(
-        state.records,
-        state.searchQuery,
-        state.searchField,
-        searchTexts
-    ) {
-        filterHistoryRecords(state.records, state.searchField, state.searchQuery, searchTexts)
+    val searchResult = remember(state.records, state.searchCriteria, searchTexts) {
+        resolveHistorySearchResult(state.records, state.searchCriteria, searchTexts)
     }
-    val hasNoSearchResults = hasNoHistorySearchResults(
-        records = state.records,
-        query = state.searchQuery,
-        visibleRecords = visibleRecords
-    )
+    val visibleRecords = searchResult.records
 
     var selectedRecord by remember { mutableStateOf<OperationHistoryModel?>(null) }
     var showClearConfirmDialog by remember { mutableStateOf(false) }
-    var searchBarActivated by rememberSaveable { mutableStateOf(false) }
-    val hasSearchState =
-        state.searchQuery.isNotBlank() || state.searchField != HistorySearchField.ALL
-    val searchBarVisible = searchBarActivated || hasSearchState
+    var searchBarActivated by rememberSaveable {
+        mutableStateOf(state.searchCriteria.isActive)
+    }
     val searchFocusRequester = remember { FocusRequester() }
     val sheetState = rememberBottomSheetState(
         initialValue = SheetValue.Hidden,
@@ -159,13 +148,11 @@ fun HistoryPage(
                         )
                     },
                     actions = {
-                        if (!searchBarVisible) {
-                            IconButton(onClick = { searchBarActivated = true }) {
-                                Icon(
-                                    imageVector = AppIcons.Search,
-                                    contentDescription = stringResource(R.string.search)
-                                )
-                            }
+                        IconButton(onClick = { searchBarActivated = !searchBarActivated }) {
+                            Icon(
+                                imageVector = AppIcons.Search,
+                                contentDescription = stringResource(R.string.search)
+                            )
                         }
                         IconButton(
                             enabled = state.records.isNotEmpty(),
@@ -185,16 +172,12 @@ fun HistoryPage(
                     )
                 )
 
-                if (searchBarVisible) {
+                if (searchBarActivated) {
                     HistorySearchControls(
                         state = state,
                         searchFocusRequester = searchFocusRequester,
                         onClose = {
-                            searchBarActivated = false
-                            viewModel.dispatch(HistoryViewAction.Search(""))
-                            viewModel.dispatch(
-                                HistoryViewAction.SelectSearchField(HistorySearchField.ALL)
-                            )
+                            viewModel.dispatch(HistoryViewAction.ClearSearch)
                         },
                         dispatch = viewModel::dispatch,
                     )
@@ -247,17 +230,7 @@ fun HistoryPage(
                     if (visibleRecords.isEmpty()) {
                         item {
                             EmptyHistory(
-                                title = if (hasNoSearchResults) {
-                                    stringResource(R.string.history_search_empty_title)
-                                } else {
-                                    stringResource(R.string.history_empty_title)
-                                },
-                                description = if (hasNoSearchResults) {
-                                    stringResource(R.string.history_search_empty_desc)
-                                } else {
-                                    stringResource(R.string.history_empty_desc)
-                                },
-                                alignTop = hasNoSearchResults,
+                                emptyState = requireNotNull(searchResult.emptyState),
                                 modifier = Modifier
                                     .fillParentMaxSize()
                                     .padding(horizontal = 8.dp)
@@ -373,7 +346,7 @@ private fun HistorySearchControls(
                 modifier = Modifier
                     .fillMaxWidth()
                     .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
-                value = stringResource(state.searchField.labelRes()),
+                value = stringResource(state.searchCriteria.field.labelRes()),
                 onValueChange = {},
                 readOnly = true,
                 singleLine = true,
@@ -405,8 +378,8 @@ private fun HistorySearchControls(
             modifier = Modifier
                 .fillMaxWidth()
                 .focusRequester(searchFocusRequester),
-            value = state.searchQuery,
-            onValueChange = { dispatch(HistoryViewAction.Search(it)) },
+            value = state.searchCriteria.query,
+            onValueChange = { dispatch(HistoryViewAction.UpdateSearchQuery(it)) },
             singleLine = true,
             placeholder = { Text(stringResource(R.string.search)) },
             leadingIcon = {
@@ -429,23 +402,25 @@ private fun HistorySearchControls(
 
 @Composable
 private fun EmptyHistory(
-    title: String,
-    description: String,
-    alignTop: Boolean,
+    emptyState: HistoryEmptyState,
     modifier: Modifier = Modifier
 ) {
     Column(
         modifier = modifier,
-        verticalArrangement = if (alignTop) Arrangement.Top else Arrangement.Center
+        verticalArrangement = if (emptyState == HistoryEmptyState.NO_MATCHES) {
+            Arrangement.Top
+        } else {
+            Arrangement.Center
+        }
     ) {
         Text(
-            text = title,
+            text = stringResource(emptyState.titleRes()),
             style = MaterialTheme.typography.headlineSmall,
             color = MaterialTheme.colorScheme.onSurface
         )
         Spacer(modifier = Modifier.padding(top = 8.dp))
         Text(
-            text = description,
+            text = stringResource(emptyState.descriptionRes()),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryPage.kt
@@ -42,6 +42,7 @@ import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
@@ -116,7 +117,6 @@ fun HistoryPage(
     val searchResult = remember(state.records, state.searchCriteria, searchTexts) {
         resolveHistorySearchResult(state.records, state.searchCriteria, searchTexts)
     }
-    val visibleRecords = searchResult.records
 
     var selectedRecord by remember { mutableStateOf<OperationHistoryModel?>(null) }
     var showClearConfirmDialog by remember { mutableStateOf(false) }
@@ -148,7 +148,15 @@ fun HistoryPage(
                         )
                     },
                     actions = {
-                        IconButton(onClick = { searchBarActivated = !searchBarActivated }) {
+                        IconToggleButton(
+                            checked = searchBarActivated,
+                            onCheckedChange = { expanded ->
+                                searchBarActivated = expanded
+                                if (!expanded) {
+                                    viewModel.dispatch(HistoryViewAction.ClearSearch)
+                                }
+                            }
+                        ) {
                             Icon(
                                 imageVector = AppIcons.Search,
                                 contentDescription = stringResource(R.string.search)
@@ -227,33 +235,37 @@ fun HistoryPage(
                     ),
                     verticalArrangement = Arrangement.spacedBy(2.dp)
                 ) {
-                    if (visibleRecords.isEmpty()) {
-                        item {
-                            EmptyHistory(
-                                emptyState = requireNotNull(searchResult.emptyState),
-                                modifier = Modifier
-                                    .fillParentMaxSize()
-                                    .padding(horizontal = 8.dp)
-                            )
-                        }
-                    } else {
-                        itemsIndexed(
-                            items = visibleRecords,
-                            key = { _, record -> record.id },
-                            contentType = { _, _ -> "history_record" }
-                        ) { index, record ->
-                            val shape = when {
-                                visibleRecords.size == 1 -> singleShape
-                                index == 0 -> topShape
-                                index == visibleRecords.lastIndex -> bottomShape
-                                else -> middleShape
+                    when (val result = searchResult) {
+                        is HistorySearchResult.Empty -> {
+                            item {
+                                EmptyHistory(
+                                    emptyState = result.state,
+                                    modifier = Modifier
+                                        .fillParentMaxSize()
+                                        .padding(horizontal = 8.dp)
+                                )
                             }
+                        }
 
-                            HistoryRecordBriefCard(
-                                record = record,
-                                shape = shape,
-                                onClick = { selectedRecord = record }
-                            )
+                        is HistorySearchResult.Records -> {
+                            itemsIndexed(
+                                items = result.records,
+                                key = { _, record -> record.id },
+                                contentType = { _, _ -> "history_record" }
+                            ) { index, record ->
+                                val shape = when {
+                                    result.records.size == 1 -> singleShape
+                                    index == 0 -> topShape
+                                    index == result.records.lastIndex -> bottomShape
+                                    else -> middleShape
+                                }
+
+                                HistoryRecordBriefCard(
+                                    record = record,
+                                    shape = shape,
+                                    onClick = { selectedRecord = record }
+                                )
+                            }
                         }
                     }
                 }
@@ -534,7 +546,7 @@ fun HistoryRecordDetailContent(
                     value = record.timestamp.formatHistoryTime()
                 )
 
-                if (record.installMethod != InstallMethod.SESSION) {
+                if (record.hasPackageManagerDetails()) {
                     HistoryInfoLine(
                         title = stringResource(R.string.history_version_change),
                         value = stringResource(record.versionChange.labelRes())
@@ -558,7 +570,7 @@ fun HistoryRecordDetailContent(
                     value = record.installerPackageName ?: stringResource(R.string.history_unknown)
                 )
 
-                if (record.installMethod != InstallMethod.SESSION) {
+                if (record.hasPackageManagerDetails()) {
                     HistoryInfoLine(
                         title = stringResource(R.string.history_apk_path),
                         value = sourcePathText(record)

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistorySearch.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistorySearch.kt
@@ -89,10 +89,11 @@ data class HistorySearchTexts(
     val formatTime: (Long) -> String = Long::toString
 )
 
-data class HistorySearchResult(
-    val records: List<OperationHistoryModel>,
-    val emptyState: HistoryEmptyState?
-)
+sealed interface HistorySearchResult {
+    data class Records(val records: List<OperationHistoryModel>) : HistorySearchResult
+
+    data class Empty(val state: HistoryEmptyState) : HistorySearchResult
+}
 
 @Composable
 fun rememberHistorySearchTexts(isSystemApp: Boolean): HistorySearchTexts {
@@ -155,13 +156,17 @@ fun resolveHistorySearchResult(
     texts: HistorySearchTexts
 ): HistorySearchResult {
     val visibleRecords = filterHistoryRecords(records, criteria, texts)
-    val emptyState = when {
-        visibleRecords.isNotEmpty() -> null
-        records.isEmpty() -> HistoryEmptyState.NO_HISTORY
-        else -> HistoryEmptyState.NO_MATCHES
+    return if (visibleRecords.isEmpty()) {
+        HistorySearchResult.Empty(
+            state = if (records.isEmpty()) {
+                HistoryEmptyState.NO_HISTORY
+            } else {
+                HistoryEmptyState.NO_MATCHES
+            }
+        )
+    } else {
+        HistorySearchResult.Records(visibleRecords)
     }
-
-    return HistorySearchResult(records = visibleRecords, emptyState = emptyState)
 }
 
 private fun searchableValues(
@@ -191,24 +196,24 @@ private fun searchableValues(
         record.timestamp.toString()
     )
 
-    HistorySearchField.VERSION_CHANGE -> record.nonSessionValues {
+    HistorySearchField.VERSION_CHANGE -> record.packageManagerDetailValues {
         valuesOf(
             texts.versionChanges[record.versionChange],
             record.versionChange.name
         )
     }
 
-    HistorySearchField.VERSION_NAME -> record.nonSessionValues {
+    HistorySearchField.VERSION_NAME -> record.packageManagerDetailValues {
         valuesWithFallback(texts.none, record.oldVersionName, record.newVersionName)
     }
 
-    HistorySearchField.VERSION_CODE -> record.nonSessionValues {
+    HistorySearchField.VERSION_CODE -> record.packageManagerDetailValues {
         valuesWithFallback(texts.none, record.oldVersionCode?.toString(), record.newVersionCode?.toString())
     }
 
     HistorySearchField.INITIATOR -> valueOrFallback(record.initiatorPackageName, texts.unknown)
     HistorySearchField.INSTALLER_PACKAGE -> valueOrFallback(record.installerPackageName, texts.unknown)
-    HistorySearchField.APK_PATH -> record.nonSessionValues {
+    HistorySearchField.APK_PATH -> record.packageManagerDetailValues {
         if (record.sourcePaths.isEmpty()) {
             sequenceOf(texts.none)
         } else {
@@ -249,6 +254,6 @@ private fun valuesOrFallback(fallback: String, vararg values: String?): Sequence
     return if (nonBlankValues.isEmpty()) sequenceOf(fallback) else nonBlankValues.asSequence()
 }
 
-private inline fun OperationHistoryModel.nonSessionValues(
+private inline fun OperationHistoryModel.packageManagerDetailValues(
     values: () -> Sequence<String>
-): Sequence<String> = if (installMethod == InstallMethod.SESSION) emptySequence() else values()
+): Sequence<String> = if (hasPackageManagerDetails()) values() else emptySequence()

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistorySearch.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistorySearch.kt
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (C) 2026 InstallerX Revived contributors
+package com.rosan.installer.ui.page.main.settings.history
+
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
+import com.rosan.installer.R
+import com.rosan.installer.domain.history.model.InstallMethod
+import com.rosan.installer.domain.history.model.OperationHistoryModel
+import com.rosan.installer.domain.history.model.OperationStatus
+import com.rosan.installer.domain.history.model.OperationType
+import com.rosan.installer.domain.history.model.VersionChange
+import com.rosan.installer.domain.settings.model.config.Authorizer
+
+enum class HistorySearchField {
+    ALL,
+    APP_LABEL,
+    PACKAGE_NAME,
+    OPERATION_TYPE,
+    STATUS,
+    TIME,
+    VERSION_CHANGE,
+    VERSION_NAME,
+    VERSION_CODE,
+    INITIATOR,
+    INSTALLER_PACKAGE,
+    APK_PATH,
+    METHOD,
+    AUTHORIZER,
+    ERROR
+}
+
+@StringRes
+fun HistorySearchField.labelRes(): Int = when (this) {
+    HistorySearchField.ALL -> R.string.history_search_field_all
+    HistorySearchField.APP_LABEL -> R.string.history_app_name
+    HistorySearchField.PACKAGE_NAME -> R.string.history_package_name
+    HistorySearchField.OPERATION_TYPE -> R.string.history_operation_type
+    HistorySearchField.STATUS -> R.string.history_status
+    HistorySearchField.TIME -> R.string.history_time
+    HistorySearchField.VERSION_CHANGE -> R.string.history_version_change
+    HistorySearchField.VERSION_NAME -> R.string.history_version_name
+    HistorySearchField.VERSION_CODE -> R.string.history_version_code
+    HistorySearchField.INITIATOR -> R.string.history_initiator
+    HistorySearchField.INSTALLER_PACKAGE -> R.string.history_installer_package
+    HistorySearchField.APK_PATH -> R.string.history_apk_path
+    HistorySearchField.METHOD -> R.string.history_method
+    HistorySearchField.AUTHORIZER -> R.string.history_authorizer
+    HistorySearchField.ERROR -> R.string.history_error
+}
+
+data class HistorySearchTexts(
+    val operationTypes: Map<OperationType, String> = emptyMap(),
+    val statuses: Map<OperationStatus, String> = emptyMap(),
+    val versionChanges: Map<VersionChange, String> = emptyMap(),
+    val installMethods: Map<InstallMethod, String> = emptyMap(),
+    val authorizers: Map<Authorizer, String> = emptyMap(),
+    val formatTime: (Long) -> String = Long::toString
+)
+
+@Composable
+fun rememberHistorySearchTexts(isSystemApp: Boolean): HistorySearchTexts {
+    val configuration = LocalConfiguration.current
+    val operationTypes = OperationType.entries.associateWith { stringResource(it.labelRes()) }
+    val statuses = OperationStatus.entries.associateWith { stringResource(it.labelRes()) }
+    val versionChanges = VersionChange.entries.associateWith { stringResource(it.labelRes()) }
+    val installMethods = InstallMethod.entries.associateWith { stringResource(it.labelRes()) }
+    val authorizers = Authorizer.entries.associateWith { authorizer ->
+        if (authorizer == Authorizer.None && isSystemApp) {
+            stringResource(R.string.working_status_system_installer)
+        } else {
+            stringResource(authorizer.displayNameRes)
+        }
+    }
+
+    return remember(
+        configuration.locales.toLanguageTags(),
+        operationTypes,
+        statuses,
+        versionChanges,
+        installMethods,
+        authorizers
+    ) {
+        HistorySearchTexts(
+            operationTypes = operationTypes,
+            statuses = statuses,
+            versionChanges = versionChanges,
+            installMethods = installMethods,
+            authorizers = authorizers,
+            formatTime = { it.formatHistoryTime() }
+        )
+    }
+}
+
+fun filterHistoryRecords(
+    records: List<OperationHistoryModel>,
+    field: HistorySearchField,
+    query: String,
+    texts: HistorySearchTexts
+): List<OperationHistoryModel> {
+    val normalizedQuery = query.trim()
+    if (normalizedQuery.isEmpty()) return records
+
+    return records.filter { record ->
+        searchableValues(record, field, texts).any { value ->
+            value.contains(normalizedQuery, ignoreCase = true)
+        }
+    }
+}
+
+private fun searchableValues(
+    record: OperationHistoryModel,
+    field: HistorySearchField,
+    texts: HistorySearchTexts
+): Sequence<String> = when (field) {
+    HistorySearchField.ALL -> HistorySearchField.entries
+        .asSequence()
+        .filter { it != HistorySearchField.ALL }
+        .flatMap { searchableValues(record, it, texts) }
+
+    HistorySearchField.APP_LABEL -> valuesOf(record.appLabel)
+    HistorySearchField.PACKAGE_NAME -> sequenceOf(record.packageName)
+    HistorySearchField.OPERATION_TYPE -> valuesOf(
+        texts.operationTypes[record.operationType],
+        record.operationType.name
+    )
+
+    HistorySearchField.STATUS -> valuesOf(
+        texts.statuses[record.status],
+        record.status.name
+    )
+
+    HistorySearchField.TIME -> sequenceOf(
+        texts.formatTime(record.timestamp),
+        record.timestamp.toString()
+    )
+
+    HistorySearchField.VERSION_CHANGE -> valuesOf(
+        texts.versionChanges[record.versionChange],
+        record.versionChange.name
+    )
+
+    HistorySearchField.VERSION_NAME -> valuesOf(
+        record.oldVersionName,
+        record.newVersionName
+    )
+
+    HistorySearchField.VERSION_CODE -> valuesOf(
+        record.oldVersionCode?.toString(),
+        record.newVersionCode?.toString()
+    )
+
+    HistorySearchField.INITIATOR -> valuesOf(record.initiatorPackageName)
+    HistorySearchField.INSTALLER_PACKAGE -> valuesOf(record.installerPackageName)
+    HistorySearchField.APK_PATH -> record.sourcePaths.asSequence()
+
+    HistorySearchField.METHOD -> valuesOf(
+        texts.installMethods[record.installMethod],
+        record.installMethod.name
+    )
+
+    HistorySearchField.AUTHORIZER -> valuesOf(
+        texts.authorizers[record.authorizer],
+        record.authorizer.value
+    )
+
+    HistorySearchField.ERROR -> valuesOf(record.errorType, record.errorSummary)
+}
+
+private fun valuesOf(vararg values: String?): Sequence<String> =
+    values.asSequence().filterNotNull()

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistorySearch.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistorySearch.kt
@@ -111,6 +111,12 @@ fun filterHistoryRecords(
     }
 }
 
+fun hasNoHistorySearchResults(
+    records: List<OperationHistoryModel>,
+    query: String,
+    visibleRecords: List<OperationHistoryModel>
+): Boolean = records.isNotEmpty() && query.isNotBlank() && visibleRecords.isEmpty()
+
 private fun searchableValues(
     record: OperationHistoryModel,
     field: HistorySearchField,

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistorySearch.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistorySearch.kt
@@ -15,6 +15,7 @@ import com.rosan.installer.domain.history.model.OperationType
 import com.rosan.installer.domain.history.model.VersionChange
 import com.rosan.installer.domain.settings.model.config.Authorizer
 
+/** User-visible record fields that can be targeted by history search. */
 enum class HistorySearchField {
     ALL,
     APP_LABEL,
@@ -31,6 +32,19 @@ enum class HistorySearchField {
     METHOD,
     AUTHORIZER,
     ERROR
+}
+
+data class HistorySearchCriteria(
+    val query: String = "",
+    val field: HistorySearchField = HistorySearchField.ALL
+) {
+    val isActive: Boolean
+        get() = query.isNotBlank() || this.field != HistorySearchField.ALL
+}
+
+enum class HistoryEmptyState {
+    NO_HISTORY,
+    NO_MATCHES
 }
 
 @StringRes
@@ -52,13 +66,32 @@ fun HistorySearchField.labelRes(): Int = when (this) {
     HistorySearchField.ERROR -> R.string.history_error
 }
 
+@StringRes
+fun HistoryEmptyState.titleRes(): Int = when (this) {
+    HistoryEmptyState.NO_HISTORY -> R.string.history_empty_title
+    HistoryEmptyState.NO_MATCHES -> R.string.history_search_empty_title
+}
+
+@StringRes
+fun HistoryEmptyState.descriptionRes(): Int = when (this) {
+    HistoryEmptyState.NO_HISTORY -> R.string.history_empty_desc
+    HistoryEmptyState.NO_MATCHES -> R.string.history_search_empty_desc
+}
+
 data class HistorySearchTexts(
     val operationTypes: Map<OperationType, String> = emptyMap(),
     val statuses: Map<OperationStatus, String> = emptyMap(),
     val versionChanges: Map<VersionChange, String> = emptyMap(),
     val installMethods: Map<InstallMethod, String> = emptyMap(),
     val authorizers: Map<Authorizer, String> = emptyMap(),
+    val unknown: String = "",
+    val none: String = "",
     val formatTime: (Long) -> String = Long::toString
+)
+
+data class HistorySearchResult(
+    val records: List<OperationHistoryModel>,
+    val emptyState: HistoryEmptyState?
 )
 
 @Composable
@@ -68,6 +101,8 @@ fun rememberHistorySearchTexts(isSystemApp: Boolean): HistorySearchTexts {
     val statuses = OperationStatus.entries.associateWith { stringResource(it.labelRes()) }
     val versionChanges = VersionChange.entries.associateWith { stringResource(it.labelRes()) }
     val installMethods = InstallMethod.entries.associateWith { stringResource(it.labelRes()) }
+    val unknown = stringResource(R.string.history_unknown)
+    val none = stringResource(R.string.history_none)
     val authorizers = Authorizer.entries.associateWith { authorizer ->
         if (authorizer == Authorizer.None && isSystemApp) {
             stringResource(R.string.working_status_system_installer)
@@ -82,7 +117,9 @@ fun rememberHistorySearchTexts(isSystemApp: Boolean): HistorySearchTexts {
         statuses,
         versionChanges,
         installMethods,
-        authorizers
+        authorizers,
+        unknown,
+        none
     ) {
         HistorySearchTexts(
             operationTypes = operationTypes,
@@ -90,6 +127,8 @@ fun rememberHistorySearchTexts(isSystemApp: Boolean): HistorySearchTexts {
             versionChanges = versionChanges,
             installMethods = installMethods,
             authorizers = authorizers,
+            unknown = unknown,
+            none = none,
             formatTime = { it.formatHistoryTime() }
         )
     }
@@ -97,25 +136,33 @@ fun rememberHistorySearchTexts(isSystemApp: Boolean): HistorySearchTexts {
 
 fun filterHistoryRecords(
     records: List<OperationHistoryModel>,
-    field: HistorySearchField,
-    query: String,
+    criteria: HistorySearchCriteria,
     texts: HistorySearchTexts
 ): List<OperationHistoryModel> {
-    val normalizedQuery = query.trim()
+    val normalizedQuery = criteria.query.trim()
     if (normalizedQuery.isEmpty()) return records
 
     return records.filter { record ->
-        searchableValues(record, field, texts).any { value ->
+        searchableValues(record, criteria.field, texts).any { value ->
             value.contains(normalizedQuery, ignoreCase = true)
         }
     }
 }
 
-fun hasNoHistorySearchResults(
+fun resolveHistorySearchResult(
     records: List<OperationHistoryModel>,
-    query: String,
-    visibleRecords: List<OperationHistoryModel>
-): Boolean = records.isNotEmpty() && query.isNotBlank() && visibleRecords.isEmpty()
+    criteria: HistorySearchCriteria,
+    texts: HistorySearchTexts
+): HistorySearchResult {
+    val visibleRecords = filterHistoryRecords(records, criteria, texts)
+    val emptyState = when {
+        visibleRecords.isNotEmpty() -> null
+        records.isEmpty() -> HistoryEmptyState.NO_HISTORY
+        else -> HistoryEmptyState.NO_MATCHES
+    }
+
+    return HistorySearchResult(records = visibleRecords, emptyState = emptyState)
+}
 
 private fun searchableValues(
     record: OperationHistoryModel,
@@ -144,24 +191,30 @@ private fun searchableValues(
         record.timestamp.toString()
     )
 
-    HistorySearchField.VERSION_CHANGE -> valuesOf(
-        texts.versionChanges[record.versionChange],
-        record.versionChange.name
-    )
+    HistorySearchField.VERSION_CHANGE -> record.nonSessionValues {
+        valuesOf(
+            texts.versionChanges[record.versionChange],
+            record.versionChange.name
+        )
+    }
 
-    HistorySearchField.VERSION_NAME -> valuesOf(
-        record.oldVersionName,
-        record.newVersionName
-    )
+    HistorySearchField.VERSION_NAME -> record.nonSessionValues {
+        valuesWithFallback(texts.none, record.oldVersionName, record.newVersionName)
+    }
 
-    HistorySearchField.VERSION_CODE -> valuesOf(
-        record.oldVersionCode?.toString(),
-        record.newVersionCode?.toString()
-    )
+    HistorySearchField.VERSION_CODE -> record.nonSessionValues {
+        valuesWithFallback(texts.none, record.oldVersionCode?.toString(), record.newVersionCode?.toString())
+    }
 
-    HistorySearchField.INITIATOR -> valuesOf(record.initiatorPackageName)
-    HistorySearchField.INSTALLER_PACKAGE -> valuesOf(record.installerPackageName)
-    HistorySearchField.APK_PATH -> record.sourcePaths.asSequence()
+    HistorySearchField.INITIATOR -> valueOrFallback(record.initiatorPackageName, texts.unknown)
+    HistorySearchField.INSTALLER_PACKAGE -> valueOrFallback(record.installerPackageName, texts.unknown)
+    HistorySearchField.APK_PATH -> record.nonSessionValues {
+        if (record.sourcePaths.isEmpty()) {
+            sequenceOf(texts.none)
+        } else {
+            record.sourcePaths.asSequence()
+        }
+    }
 
     HistorySearchField.METHOD -> valuesOf(
         texts.installMethods[record.installMethod],
@@ -173,8 +226,29 @@ private fun searchableValues(
         record.authorizer.value
     )
 
-    HistorySearchField.ERROR -> valuesOf(record.errorType, record.errorSummary)
+    HistorySearchField.ERROR -> if (record.status == OperationStatus.FAILED) {
+        valuesOrFallback(texts.unknown, record.errorType, record.errorSummary)
+    } else {
+        emptySequence()
+    }
 }
 
 private fun valuesOf(vararg values: String?): Sequence<String> =
     values.asSequence().filterNotNull()
+
+private fun valuesWithFallback(fallback: String, vararg values: String?): Sequence<String> =
+    values.asSequence()
+        .map { it?.takeIf(String::isNotBlank) ?: fallback }
+        .distinct()
+
+private fun valueOrFallback(value: String?, fallback: String): Sequence<String> =
+    sequenceOf(value ?: fallback)
+
+private fun valuesOrFallback(fallback: String, vararg values: String?): Sequence<String> {
+    val nonBlankValues = values.filterNotNull().filter { it.isNotBlank() }
+    return if (nonBlankValues.isEmpty()) sequenceOf(fallback) else nonBlankValues.asSequence()
+}
+
+private inline fun OperationHistoryModel.nonSessionValues(
+    values: () -> Sequence<String>
+): Sequence<String> = if (installMethod == InstallMethod.SESSION) emptySequence() else values()

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistorySearch.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistorySearch.kt
@@ -179,7 +179,7 @@ private fun searchableValues(
         .filter { it != HistorySearchField.ALL }
         .flatMap { searchableValues(record, it, texts) }
 
-    HistorySearchField.APP_LABEL -> valuesOf(record.appLabel)
+    HistorySearchField.APP_LABEL -> valuesOf(record.appLabel ?: record.packageName)
     HistorySearchField.PACKAGE_NAME -> sequenceOf(record.packageName)
     HistorySearchField.OPERATION_TYPE -> valuesOf(
         texts.operationTypes[record.operationType],

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryViewAction.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryViewAction.kt
@@ -4,4 +4,6 @@ package com.rosan.installer.ui.page.main.settings.history
 
 sealed interface HistoryViewAction {
     data object ClearHistory : HistoryViewAction
+    data class Search(val query: String) : HistoryViewAction
+    data class SelectSearchField(val field: HistorySearchField) : HistoryViewAction
 }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryViewAction.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryViewAction.kt
@@ -4,6 +4,7 @@ package com.rosan.installer.ui.page.main.settings.history
 
 sealed interface HistoryViewAction {
     data object ClearHistory : HistoryViewAction
-    data class Search(val query: String) : HistoryViewAction
+    data class UpdateSearchQuery(val query: String) : HistoryViewAction
     data class SelectSearchField(val field: HistorySearchField) : HistoryViewAction
+    data object ClearSearch : HistoryViewAction
 }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryViewModel.kt
@@ -7,19 +7,29 @@ import androidx.lifecycle.viewModelScope
 import com.rosan.installer.domain.device.provider.DeviceCapabilityProvider
 import com.rosan.installer.domain.history.repository.OperationHistoryRepository
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class HistoryViewModel(
     private val repository: OperationHistoryRepository,
     private val capabilityProvider: DeviceCapabilityProvider
 ) : ViewModel() {
-    val state: StateFlow<HistoryViewState> = repository.flowAll()
-        .map {
+    private val searchQuery = MutableStateFlow("")
+    private val searchField = MutableStateFlow(HistorySearchField.ALL)
+
+    val state: StateFlow<HistoryViewState> = combine(
+        repository.flowAll(),
+        searchQuery,
+        searchField
+    ) { records, query, field ->
             HistoryViewState(
-                records = it,
+                records = records,
+                searchQuery = query,
+                searchField = field,
                 isLoading = false,
                 isSystemApp = capabilityProvider.isSystemApp
             )
@@ -35,6 +45,9 @@ class HistoryViewModel(
             HistoryViewAction.ClearHistory -> viewModelScope.launch {
                 repository.clear()
             }
+
+            is HistoryViewAction.Search -> searchQuery.update { action.query }
+            is HistoryViewAction.SelectSearchField -> searchField.update { action.field }
         }
     }
 }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryViewModel.kt
@@ -18,18 +18,15 @@ class HistoryViewModel(
     private val repository: OperationHistoryRepository,
     private val capabilityProvider: DeviceCapabilityProvider
 ) : ViewModel() {
-    private val searchQuery = MutableStateFlow("")
-    private val searchField = MutableStateFlow(HistorySearchField.ALL)
+    private val searchCriteria = MutableStateFlow(HistorySearchCriteria())
 
     val state: StateFlow<HistoryViewState> = combine(
         repository.flowAll(),
-        searchQuery,
-        searchField
-    ) { records, query, field ->
+        searchCriteria
+    ) { records, criteria ->
             HistoryViewState(
                 records = records,
-                searchQuery = query,
-                searchField = field,
+                searchCriteria = criteria,
                 isLoading = false,
                 isSystemApp = capabilityProvider.isSystemApp
             )
@@ -46,8 +43,15 @@ class HistoryViewModel(
                 repository.clear()
             }
 
-            is HistoryViewAction.Search -> searchQuery.update { action.query }
-            is HistoryViewAction.SelectSearchField -> searchField.update { action.field }
+            is HistoryViewAction.UpdateSearchQuery -> searchCriteria.update {
+                it.copy(query = action.query)
+            }
+
+            is HistoryViewAction.SelectSearchField -> searchCriteria.update {
+                it.copy(field = action.field)
+            }
+
+            HistoryViewAction.ClearSearch -> searchCriteria.value = HistorySearchCriteria()
         }
     }
 }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryViewState.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryViewState.kt
@@ -6,6 +6,8 @@ import com.rosan.installer.domain.history.model.OperationHistoryModel
 
 data class HistoryViewState(
     val records: List<OperationHistoryModel> = emptyList(),
+    val searchQuery: String = "",
+    val searchField: HistorySearchField = HistorySearchField.ALL,
     val isLoading: Boolean = true,
     val isSystemApp: Boolean = false
 )

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryViewState.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/history/HistoryViewState.kt
@@ -6,8 +6,7 @@ import com.rosan.installer.domain.history.model.OperationHistoryModel
 
 data class HistoryViewState(
     val records: List<OperationHistoryModel> = emptyList(),
-    val searchQuery: String = "",
-    val searchField: HistorySearchField = HistorySearchField.ALL,
+    val searchCriteria: HistorySearchCriteria = HistorySearchCriteria(),
     val isLoading: Boolean = true,
     val isSystemApp: Boolean = false
 )

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/history/MiuixHistoryPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/history/MiuixHistoryPage.kt
@@ -57,6 +57,7 @@ import com.rosan.installer.ui.page.main.settings.history.HistoryViewModel
 import com.rosan.installer.ui.page.main.settings.history.HistorySearchField
 import com.rosan.installer.ui.page.main.settings.history.filterHistoryRecords
 import com.rosan.installer.ui.page.main.settings.history.formatHistoryTime
+import com.rosan.installer.ui.page.main.settings.history.hasNoHistorySearchResults
 import com.rosan.installer.ui.page.main.settings.history.historyAuthorizerText
 import com.rosan.installer.ui.page.main.settings.history.labelRes
 import com.rosan.installer.ui.page.main.settings.history.rememberHistorySearchTexts
@@ -108,6 +109,11 @@ fun MiuixHistoryPage(
     ) {
         filterHistoryRecords(state.records, state.searchField, state.searchQuery, searchTexts)
     }
+    val hasNoSearchResults = hasNoHistorySearchResults(
+        records = state.records,
+        query = state.searchQuery,
+        visibleRecords = visibleRecords
+    )
     var selectedRecord by remember { mutableStateOf<OperationHistoryModel?>(null) }
     var showRecordDetailSheet by remember { mutableStateOf(false) }
     var showClearConfirmDialog by remember { mutableStateOf(false) }
@@ -215,16 +221,17 @@ fun MiuixHistoryPage(
                 if (visibleRecords.isEmpty()) {
                     item {
                         EmptyHistory(
-                            title = if (state.records.isNotEmpty() && state.searchQuery.isNotBlank()) {
+                            title = if (hasNoSearchResults) {
                                 stringResource(R.string.history_search_empty_title)
                             } else {
                                 stringResource(R.string.history_empty_title)
                             },
-                            description = if (state.records.isNotEmpty() && state.searchQuery.isNotBlank()) {
+                            description = if (hasNoSearchResults) {
                                 stringResource(R.string.history_search_empty_desc)
                             } else {
                                 stringResource(R.string.history_empty_desc)
                             },
+                            alignTop = hasNoSearchResults,
                             modifier = Modifier
                                 .fillParentMaxSize()
                                 .padding(horizontal = 8.dp)
@@ -285,11 +292,12 @@ fun MiuixHistoryPage(
 private fun EmptyHistory(
     title: String,
     description: String,
+    alignTop: Boolean,
     modifier: Modifier = Modifier
 ) {
     Column(
         modifier = modifier,
-        verticalArrangement = Arrangement.Top
+        verticalArrangement = if (alignTop) Arrangement.Top else Arrangement.Center
     ) {
         Text(
             text = title,

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/history/MiuixHistoryPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/history/MiuixHistoryPage.kt
@@ -3,6 +3,7 @@
 package com.rosan.installer.ui.page.miuix.settings.history
 
 import android.content.ClipData
+import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -11,6 +12,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
@@ -18,7 +20,9 @@ import androidx.compose.foundation.layout.captionBar
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -30,6 +34,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalClipboard
@@ -49,10 +54,14 @@ import com.rosan.installer.domain.history.model.OperationStatus
 import com.rosan.installer.ui.icons.AppMiuixIcons
 import com.rosan.installer.ui.page.main.settings.history.HistoryViewAction
 import com.rosan.installer.ui.page.main.settings.history.HistoryViewModel
+import com.rosan.installer.ui.page.main.settings.history.HistorySearchField
+import com.rosan.installer.ui.page.main.settings.history.filterHistoryRecords
 import com.rosan.installer.ui.page.main.settings.history.formatHistoryTime
 import com.rosan.installer.ui.page.main.settings.history.historyAuthorizerText
 import com.rosan.installer.ui.page.main.settings.history.labelRes
+import com.rosan.installer.ui.page.main.settings.history.rememberHistorySearchTexts
 import com.rosan.installer.ui.page.miuix.widgets.MiuixBackButton
+import com.rosan.installer.ui.page.miuix.widgets.MiuixDropdown
 import com.rosan.installer.ui.theme.getMiuixAppBarColor
 import com.rosan.installer.ui.theme.installerMiuixBlurEffect
 import com.rosan.installer.ui.theme.rememberMiuixBlurBackdrop
@@ -64,6 +73,7 @@ import top.yukonga.miuix.kmp.basic.Card
 import top.yukonga.miuix.kmp.basic.Icon
 import top.yukonga.miuix.kmp.basic.IconButton
 import top.yukonga.miuix.kmp.basic.InfiniteProgressIndicator
+import top.yukonga.miuix.kmp.basic.InputField
 import top.yukonga.miuix.kmp.basic.MiuixScrollBehavior
 import top.yukonga.miuix.kmp.basic.Scaffold
 import top.yukonga.miuix.kmp.basic.Text
@@ -88,6 +98,16 @@ fun MiuixHistoryPage(
     val scrollBehavior = MiuixScrollBehavior()
     val layoutDirection = LocalLayoutDirection.current
     val topBarBackdrop = rememberMiuixBlurBackdrop(enableBlur)
+    val horizontalSafeInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal).asPaddingValues()
+    val searchTexts = rememberHistorySearchTexts(state.isSystemApp)
+    val visibleRecords = remember(
+        state.records,
+        state.searchQuery,
+        state.searchField,
+        searchTexts
+    ) {
+        filterHistoryRecords(state.records, state.searchField, state.searchQuery, searchTexts)
+    }
     var selectedRecord by remember { mutableStateOf<OperationHistoryModel?>(null) }
     var showRecordDetailSheet by remember { mutableStateOf(false) }
     var showClearConfirmDialog by remember { mutableStateOf(false) }
@@ -95,23 +115,61 @@ fun MiuixHistoryPage(
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         topBar = {
-            TopAppBar(
-                modifier = Modifier.installerMiuixBlurEffect(topBarBackdrop),
-                color = topBarBackdrop.getMiuixAppBarColor(),
-                title = title,
-                actions = {
-                    IconButton(
-                        enabled = state.records.isNotEmpty(),
-                        onClick = { showClearConfirmDialog = true }
-                    ) {
-                        Icon(
-                            imageVector = AppMiuixIcons.Delete,
-                            contentDescription = stringResource(R.string.history_clear)
-                        )
+            Column(
+                modifier = Modifier
+                    .installerMiuixBlurEffect(topBarBackdrop)
+                    .background(topBarBackdrop.getMiuixAppBarColor())
+            ) {
+                TopAppBar(
+                    color = Color.Transparent,
+                    title = title,
+                    actions = {
+                        IconButton(
+                            enabled = state.records.isNotEmpty(),
+                            onClick = { showClearConfirmDialog = true }
+                        ) {
+                            Icon(
+                                imageVector = AppMiuixIcons.Delete,
+                                contentDescription = stringResource(R.string.history_clear)
+                            )
+                        }
+                    },
+                    scrollBehavior = scrollBehavior
+                )
+
+                val searchFields = HistorySearchField.entries
+                val selectedFieldIndex = searchFields.indexOf(state.searchField).coerceAtLeast(0)
+                MiuixDropdown(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            start = horizontalSafeInsets.calculateStartPadding(layoutDirection),
+                            end = horizontalSafeInsets.calculateEndPadding(layoutDirection)
+                        ),
+                    items = searchFields.map { stringResource(it.labelRes()) },
+                    selectedIndex = selectedFieldIndex,
+                    onSelectedIndexChange = { index ->
+                        searchFields.getOrNull(index)?.let {
+                            viewModel.dispatch(HistoryViewAction.SelectSearchField(it))
+                        }
                     }
-                },
-                scrollBehavior = scrollBehavior
-            )
+                )
+                InputField(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            start = 16.dp + horizontalSafeInsets.calculateStartPadding(layoutDirection),
+                            end = 16.dp + horizontalSafeInsets.calculateEndPadding(layoutDirection),
+                            bottom = 8.dp
+                        ),
+                    query = state.searchQuery,
+                    onQueryChange = { viewModel.dispatch(HistoryViewAction.Search(it)) },
+                    label = stringResource(R.string.search),
+                    expanded = false,
+                    onExpandedChange = {},
+                    onSearch = {}
+                )
+            }
         }
     ) { innerPadding ->
         if (state.isLoading && state.records.isEmpty()) {
@@ -154,16 +212,26 @@ fun MiuixHistoryPage(
                 ),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                if (state.records.isEmpty()) {
+                if (visibleRecords.isEmpty()) {
                     item {
                         EmptyHistory(
+                            title = if (state.records.isNotEmpty() && state.searchQuery.isNotBlank()) {
+                                stringResource(R.string.history_search_empty_title)
+                            } else {
+                                stringResource(R.string.history_empty_title)
+                            },
+                            description = if (state.records.isNotEmpty() && state.searchQuery.isNotBlank()) {
+                                stringResource(R.string.history_search_empty_desc)
+                            } else {
+                                stringResource(R.string.history_empty_desc)
+                            },
                             modifier = Modifier
                                 .fillParentMaxSize()
                                 .padding(horizontal = 8.dp)
                         )
                     }
                 } else {
-                    items(state.records, key = { it.id }) { record ->
+                    items(visibleRecords, key = { it.id }) { record ->
                         HistoryRecordBriefCard(
                             record = record,
                             onClick = {
@@ -214,19 +282,23 @@ fun MiuixHistoryPage(
 }
 
 @Composable
-private fun EmptyHistory(modifier: Modifier = Modifier) {
+private fun EmptyHistory(
+    title: String,
+    description: String,
+    modifier: Modifier = Modifier
+) {
     Column(
         modifier = modifier,
-        verticalArrangement = Arrangement.Center
+        verticalArrangement = Arrangement.Top
     ) {
         Text(
-            text = stringResource(R.string.history_empty_title),
+            text = title,
             style = MiuixTheme.textStyles.title2,
             color = MiuixTheme.colorScheme.onSurface
         )
         Spacer(modifier = Modifier.size(8.dp))
         Text(
-            text = stringResource(R.string.history_empty_desc),
+            text = description,
             style = MiuixTheme.textStyles.subtitle,
             color = MiuixTheme.colorScheme.onSurfaceVariantSummary
         )

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/history/MiuixHistoryPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/history/MiuixHistoryPage.kt
@@ -55,9 +55,11 @@ import com.rosan.installer.ui.icons.AppMiuixIcons
 import com.rosan.installer.ui.page.main.settings.history.HistoryViewAction
 import com.rosan.installer.ui.page.main.settings.history.HistoryViewModel
 import com.rosan.installer.ui.page.main.settings.history.HistoryEmptyState
+import com.rosan.installer.ui.page.main.settings.history.HistorySearchResult
 import com.rosan.installer.ui.page.main.settings.history.HistorySearchField
 import com.rosan.installer.ui.page.main.settings.history.descriptionRes
 import com.rosan.installer.ui.page.main.settings.history.formatHistoryTime
+import com.rosan.installer.ui.page.main.settings.history.hasPackageManagerDetails
 import com.rosan.installer.ui.page.main.settings.history.historyAuthorizerText
 import com.rosan.installer.ui.page.main.settings.history.labelRes
 import com.rosan.installer.ui.page.main.settings.history.rememberHistorySearchTexts
@@ -106,7 +108,6 @@ fun MiuixHistoryPage(
     val searchResult = remember(state.records, state.searchCriteria, searchTexts) {
         resolveHistorySearchResult(state.records, state.searchCriteria, searchTexts)
     }
-    val visibleRecords = searchResult.records
     var selectedRecord by remember { mutableStateOf<OperationHistoryModel?>(null) }
     var showRecordDetailSheet by remember { mutableStateOf(false) }
     var showClearConfirmDialog by remember { mutableStateOf(false) }
@@ -211,24 +212,28 @@ fun MiuixHistoryPage(
                 ),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                if (visibleRecords.isEmpty()) {
-                    item {
-                        EmptyHistory(
-                            emptyState = requireNotNull(searchResult.emptyState),
-                            modifier = Modifier
-                                .fillParentMaxSize()
-                                .padding(horizontal = 8.dp)
-                        )
+                when (val result = searchResult) {
+                    is HistorySearchResult.Empty -> {
+                        item {
+                            EmptyHistory(
+                                emptyState = result.state,
+                                modifier = Modifier
+                                    .fillParentMaxSize()
+                                    .padding(horizontal = 8.dp)
+                            )
+                        }
                     }
-                } else {
-                    items(visibleRecords, key = { it.id }) { record ->
-                        HistoryRecordBriefCard(
-                            record = record,
-                            onClick = {
-                                selectedRecord = record
-                                showRecordDetailSheet = true
-                            }
-                        )
+
+                    is HistorySearchResult.Records -> {
+                        items(result.records, key = { it.id }) { record ->
+                            HistoryRecordBriefCard(
+                                record = record,
+                                onClick = {
+                                    selectedRecord = record
+                                    showRecordDetailSheet = true
+                                }
+                            )
+                        }
                     }
                 }
             }
@@ -390,7 +395,7 @@ private fun HistoryRecordDetailContent(
                 value = record.timestamp.formatHistoryTime()
             )
         }
-        if (record.installMethod != InstallMethod.SESSION) {
+        if (record.hasPackageManagerDetails()) {
             item {
                 HistoryInfoLine(
                     title = stringResource(R.string.history_version_change),
@@ -422,7 +427,7 @@ private fun HistoryRecordDetailContent(
                 value = record.installerPackageName ?: stringResource(R.string.history_unknown)
             )
         }
-        if (record.installMethod != InstallMethod.SESSION) {
+        if (record.hasPackageManagerDetails()) {
             item {
                 HistoryInfoLine(
                     title = stringResource(R.string.history_apk_path),

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/history/MiuixHistoryPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/history/MiuixHistoryPage.kt
@@ -54,13 +54,15 @@ import com.rosan.installer.domain.history.model.OperationStatus
 import com.rosan.installer.ui.icons.AppMiuixIcons
 import com.rosan.installer.ui.page.main.settings.history.HistoryViewAction
 import com.rosan.installer.ui.page.main.settings.history.HistoryViewModel
+import com.rosan.installer.ui.page.main.settings.history.HistoryEmptyState
 import com.rosan.installer.ui.page.main.settings.history.HistorySearchField
-import com.rosan.installer.ui.page.main.settings.history.filterHistoryRecords
+import com.rosan.installer.ui.page.main.settings.history.descriptionRes
 import com.rosan.installer.ui.page.main.settings.history.formatHistoryTime
-import com.rosan.installer.ui.page.main.settings.history.hasNoHistorySearchResults
 import com.rosan.installer.ui.page.main.settings.history.historyAuthorizerText
 import com.rosan.installer.ui.page.main.settings.history.labelRes
 import com.rosan.installer.ui.page.main.settings.history.rememberHistorySearchTexts
+import com.rosan.installer.ui.page.main.settings.history.resolveHistorySearchResult
+import com.rosan.installer.ui.page.main.settings.history.titleRes
 import com.rosan.installer.ui.page.miuix.widgets.MiuixBackButton
 import com.rosan.installer.ui.page.miuix.widgets.MiuixDropdown
 import com.rosan.installer.ui.theme.getMiuixAppBarColor
@@ -101,19 +103,10 @@ fun MiuixHistoryPage(
     val topBarBackdrop = rememberMiuixBlurBackdrop(enableBlur)
     val horizontalSafeInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal).asPaddingValues()
     val searchTexts = rememberHistorySearchTexts(state.isSystemApp)
-    val visibleRecords = remember(
-        state.records,
-        state.searchQuery,
-        state.searchField,
-        searchTexts
-    ) {
-        filterHistoryRecords(state.records, state.searchField, state.searchQuery, searchTexts)
+    val searchResult = remember(state.records, state.searchCriteria, searchTexts) {
+        resolveHistorySearchResult(state.records, state.searchCriteria, searchTexts)
     }
-    val hasNoSearchResults = hasNoHistorySearchResults(
-        records = state.records,
-        query = state.searchQuery,
-        visibleRecords = visibleRecords
-    )
+    val visibleRecords = searchResult.records
     var selectedRecord by remember { mutableStateOf<OperationHistoryModel?>(null) }
     var showRecordDetailSheet by remember { mutableStateOf(false) }
     var showClearConfirmDialog by remember { mutableStateOf(false) }
@@ -144,7 +137,7 @@ fun MiuixHistoryPage(
                 )
 
                 val searchFields = HistorySearchField.entries
-                val selectedFieldIndex = searchFields.indexOf(state.searchField).coerceAtLeast(0)
+                val selectedFieldIndex = searchFields.indexOf(state.searchCriteria.field).coerceAtLeast(0)
                 MiuixDropdown(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -168,8 +161,8 @@ fun MiuixHistoryPage(
                             end = 16.dp + horizontalSafeInsets.calculateEndPadding(layoutDirection),
                             bottom = 8.dp
                         ),
-                    query = state.searchQuery,
-                    onQueryChange = { viewModel.dispatch(HistoryViewAction.Search(it)) },
+                    query = state.searchCriteria.query,
+                    onQueryChange = { viewModel.dispatch(HistoryViewAction.UpdateSearchQuery(it)) },
                     label = stringResource(R.string.search),
                     expanded = false,
                     onExpandedChange = {},
@@ -221,17 +214,7 @@ fun MiuixHistoryPage(
                 if (visibleRecords.isEmpty()) {
                     item {
                         EmptyHistory(
-                            title = if (hasNoSearchResults) {
-                                stringResource(R.string.history_search_empty_title)
-                            } else {
-                                stringResource(R.string.history_empty_title)
-                            },
-                            description = if (hasNoSearchResults) {
-                                stringResource(R.string.history_search_empty_desc)
-                            } else {
-                                stringResource(R.string.history_empty_desc)
-                            },
-                            alignTop = hasNoSearchResults,
+                            emptyState = requireNotNull(searchResult.emptyState),
                             modifier = Modifier
                                 .fillParentMaxSize()
                                 .padding(horizontal = 8.dp)
@@ -290,23 +273,25 @@ fun MiuixHistoryPage(
 
 @Composable
 private fun EmptyHistory(
-    title: String,
-    description: String,
-    alignTop: Boolean,
+    emptyState: HistoryEmptyState,
     modifier: Modifier = Modifier
 ) {
     Column(
         modifier = modifier,
-        verticalArrangement = if (alignTop) Arrangement.Top else Arrangement.Center
+        verticalArrangement = if (emptyState == HistoryEmptyState.NO_MATCHES) {
+            Arrangement.Top
+        } else {
+            Arrangement.Center
+        }
     ) {
         Text(
-            text = title,
+            text = stringResource(emptyState.titleRes()),
             style = MiuixTheme.textStyles.title2,
             color = MiuixTheme.colorScheme.onSurface
         )
         Spacer(modifier = Modifier.size(8.dp))
         Text(
-            text = description,
+            text = stringResource(emptyState.descriptionRes()),
             style = MiuixTheme.textStyles.subtitle,
             color = MiuixTheme.colorScheme.onSurfaceVariantSummary
         )

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -31,6 +31,12 @@
     <string name="history">记录</string>
     <string name="history_empty_title">暂无记录</string>
     <string name="history_empty_desc">安装或卸载操作结束后，相关记录会显示在这里。</string>
+    <string name="history_search_field_all">全部条目</string>
+    <string name="history_search_scope">搜索范围</string>
+    <string name="history_app_name">应用名称</string>
+    <string name="history_status">状态</string>
+    <string name="history_search_empty_title">没有匹配的记录</string>
+    <string name="history_search_empty_desc">请尝试其他搜索关键词或条目。</string>
     <string name="history_clear">清空记录</string>
     <string name="history_clear_confirm_title">清空记录？</string>
     <string name="history_clear_confirm_desc">所有安装和卸载记录都将被删除。此操作无法撤销。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,12 @@
     <string name="history">History</string>
     <string name="history_empty_title">No records yet</string>
     <string name="history_empty_desc">Installation and uninstallation records will appear here after an operation finishes.</string>
+    <string name="history_search_field_all">All entries</string>
+    <string name="history_search_scope">Search in</string>
+    <string name="history_app_name">App name</string>
+    <string name="history_status">Status</string>
+    <string name="history_search_empty_title">No matching records</string>
+    <string name="history_search_empty_desc">Try a different search term or entry field.</string>
     <string name="history_clear">Clear history</string>
     <string name="history_clear_confirm_title">Clear history?</string>
     <string name="history_clear_confirm_desc">All installation and uninstallation records will be deleted. This cannot be undone.</string>

--- a/app/src/test/java/com/rosan/installer/ui/page/main/settings/history/HistorySearchTest.kt
+++ b/app/src/test/java/com/rosan/installer/ui/page/main/settings/history/HistorySearchTest.kt
@@ -11,6 +11,7 @@ import com.rosan.installer.domain.settings.model.config.Authorizer
 import com.rosan.installer.domain.settings.model.config.InstallMode
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class HistorySearchTest {
@@ -77,6 +78,16 @@ class HistorySearchTest {
             listOf(record),
             filterHistoryRecords(listOf(record), HistorySearchField.TIME, "12:30", texts)
         )
+    }
+
+    @Test
+    fun `search empty state only applies when a nonblank query has no matches`() {
+        val records = listOf(record())
+
+        assertTrue(hasNoHistorySearchResults(records, "missing", emptyList()))
+        assertFalse(hasNoHistorySearchResults(emptyList(), "missing", emptyList()))
+        assertFalse(hasNoHistorySearchResults(records, "  ", emptyList()))
+        assertFalse(hasNoHistorySearchResults(records, "example", records))
     }
 
     private fun record(

--- a/app/src/test/java/com/rosan/installer/ui/page/main/settings/history/HistorySearchTest.kt
+++ b/app/src/test/java/com/rosan/installer/ui/page/main/settings/history/HistorySearchTest.kt
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (C) 2026 InstallerX Revived contributors
+package com.rosan.installer.ui.page.main.settings.history
+
+import com.rosan.installer.domain.history.model.InstallMethod
+import com.rosan.installer.domain.history.model.OperationHistoryModel
+import com.rosan.installer.domain.history.model.OperationStatus
+import com.rosan.installer.domain.history.model.OperationType
+import com.rosan.installer.domain.history.model.VersionChange
+import com.rosan.installer.domain.settings.model.config.Authorizer
+import com.rosan.installer.domain.settings.model.config.InstallMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class HistorySearchTest {
+    private val texts = HistorySearchTexts(
+        operationTypes = mapOf(OperationType.INSTALL to "Install"),
+        statuses = mapOf(OperationStatus.SUCCESS to "Success"),
+        versionChanges = mapOf(VersionChange.UPDATE to "Update"),
+        installMethods = mapOf(InstallMethod.PACKAGE_MANAGER to "Package manager"),
+        authorizers = mapOf(Authorizer.Root to "Root"),
+        formatTime = { "2026-08-16 12:30" }
+    )
+
+    @Test
+    fun `all fields match every searchable record value`() {
+        val record = record()
+
+        assertEquals(listOf(record), filterHistoryRecords(listOf(record), HistorySearchField.ALL, "installer", texts))
+        assertEquals(listOf(record), filterHistoryRecords(listOf(record), HistorySearchField.ALL, "Update", texts))
+        assertEquals(listOf(record), filterHistoryRecords(listOf(record), HistorySearchField.ALL, "2026-08-16", texts))
+    }
+
+    @Test
+    fun `package field does not match installer package`() {
+        val record = record()
+
+        assertTrue(
+            filterHistoryRecords(
+                listOf(record),
+                HistorySearchField.PACKAGE_NAME,
+                "installer",
+                texts
+            ).isEmpty()
+        )
+        assertEquals(
+            listOf(record),
+            filterHistoryRecords(listOf(record), HistorySearchField.INSTALLER_PACKAGE, "installer", texts)
+        )
+    }
+
+    @Test
+    fun `blank query preserves record order`() {
+        val first = record(id = 1L, packageName = "first.package")
+        val second = record(id = 2L, packageName = "second.package")
+
+        assertEquals(
+            listOf(first, second),
+            filterHistoryRecords(listOf(first, second), HistorySearchField.PACKAGE_NAME, "  ", texts)
+        )
+    }
+
+    @Test
+    fun `localized enum and time display values are searchable`() {
+        val record = record()
+
+        assertEquals(
+            listOf(record),
+            filterHistoryRecords(listOf(record), HistorySearchField.OPERATION_TYPE, "Install", texts)
+        )
+        assertEquals(
+            listOf(record),
+            filterHistoryRecords(listOf(record), HistorySearchField.AUTHORIZER, "Root", texts)
+        )
+        assertEquals(
+            listOf(record),
+            filterHistoryRecords(listOf(record), HistorySearchField.TIME, "12:30", texts)
+        )
+    }
+
+    private fun record(
+        id: Long = 1L,
+        packageName: String = "com.example.app",
+        installerPackageName: String? = "com.example.installer"
+    ) = OperationHistoryModel(
+        id = id,
+        operationType = OperationType.INSTALL,
+        status = OperationStatus.SUCCESS,
+        packageName = packageName,
+        appLabel = "Example App",
+        timestamp = 1_755_330_600_000L,
+        versionChange = VersionChange.UPDATE,
+        oldVersionName = "1.0",
+        oldVersionCode = 1L,
+        newVersionName = "2.0",
+        newVersionCode = 2L,
+        sourcePaths = listOf("/tmp/example.apk"),
+        initiatorPackageName = "com.example.source",
+        installerPackageName = installerPackageName,
+        installMethod = InstallMethod.PACKAGE_MANAGER,
+        authorizer = Authorizer.Root,
+        installMode = InstallMode.Dialog
+    )
+}

--- a/app/src/test/java/com/rosan/installer/ui/page/main/settings/history/HistorySearchTest.kt
+++ b/app/src/test/java/com/rosan/installer/ui/page/main/settings/history/HistorySearchTest.kt
@@ -83,6 +83,19 @@ class HistorySearchTest {
     }
 
     @Test
+    fun `app name field matches package fallback shown for records without labels`() {
+        val record = record(
+            packageName = "com.example.unresolved",
+            appLabel = null
+        )
+
+        assertEquals(
+            listOf(record),
+            filter(listOf(record), HistorySearchField.APP_LABEL, "com.example.unresolved")
+        )
+    }
+
+    @Test
     fun `blank query preserves record order`() {
         val first = record(id = 1L, packageName = "first.package")
         val second = record(id = 2L, packageName = "second.package")
@@ -210,6 +223,7 @@ class HistorySearchTest {
         id: Long = 1L,
         operationType: OperationType = OperationType.INSTALL,
         packageName: String = "com.example.app",
+        appLabel: String? = "Example App",
         installerPackageName: String? = "com.example.installer",
         status: OperationStatus = OperationStatus.SUCCESS,
         versionChange: VersionChange = VersionChange.UPDATE,
@@ -227,7 +241,7 @@ class HistorySearchTest {
         operationType = operationType,
         status = status,
         packageName = packageName,
-        appLabel = "Example App",
+        appLabel = appLabel,
         timestamp = 1_755_330_600_000L,
         versionChange = versionChange,
         oldVersionName = oldVersionName,

--- a/app/src/test/java/com/rosan/installer/ui/page/main/settings/history/HistorySearchTest.kt
+++ b/app/src/test/java/com/rosan/installer/ui/page/main/settings/history/HistorySearchTest.kt
@@ -21,16 +21,52 @@ class HistorySearchTest {
         versionChanges = mapOf(VersionChange.UPDATE to "Update"),
         installMethods = mapOf(InstallMethod.PACKAGE_MANAGER to "Package manager"),
         authorizers = mapOf(Authorizer.Root to "Root"),
+        unknown = "Unknown",
+        none = "None",
         formatTime = { "2026-08-16 12:30" }
     )
 
     @Test
-    fun `all fields match every searchable record value`() {
+    fun `searchable fields match their visible values`() {
+        val record = record()
+        val failedRecord = record(
+            id = 2L,
+            status = OperationStatus.FAILED,
+            errorType = "PackageInstallerException",
+            errorSummary = "Install blocked"
+        )
+        val expectations = listOf(
+            HistorySearchField.APP_LABEL to "Example App",
+            HistorySearchField.PACKAGE_NAME to "com.example.app",
+            HistorySearchField.OPERATION_TYPE to "Install",
+            HistorySearchField.STATUS to "Success",
+            HistorySearchField.TIME to "12:30",
+            HistorySearchField.VERSION_CHANGE to "Update",
+            HistorySearchField.VERSION_NAME to "1.0",
+            HistorySearchField.VERSION_CODE to "2",
+            HistorySearchField.INITIATOR to "com.example.source",
+            HistorySearchField.INSTALLER_PACKAGE to "com.example.installer",
+            HistorySearchField.APK_PATH to "/tmp/example.apk",
+            HistorySearchField.METHOD to "Package manager",
+            HistorySearchField.AUTHORIZER to "Root"
+        )
+
+        expectations.forEach { (field, query) ->
+            assertEquals(listOf(record), filter(listOf(record), field, query))
+        }
+        assertEquals(
+            listOf(failedRecord),
+            filter(listOf(failedRecord), HistorySearchField.ERROR, "Install blocked")
+        )
+    }
+
+    @Test
+    fun `all scope matches values across searchable fields`() {
         val record = record()
 
-        assertEquals(listOf(record), filterHistoryRecords(listOf(record), HistorySearchField.ALL, "installer", texts))
-        assertEquals(listOf(record), filterHistoryRecords(listOf(record), HistorySearchField.ALL, "Update", texts))
-        assertEquals(listOf(record), filterHistoryRecords(listOf(record), HistorySearchField.ALL, "2026-08-16", texts))
+        assertEquals(listOf(record), filter(listOf(record), HistorySearchField.ALL, "installer"))
+        assertEquals(listOf(record), filter(listOf(record), HistorySearchField.ALL, "Update"))
+        assertEquals(listOf(record), filter(listOf(record), HistorySearchField.ALL, "2026-08-16"))
     }
 
     @Test
@@ -38,16 +74,11 @@ class HistorySearchTest {
         val record = record()
 
         assertTrue(
-            filterHistoryRecords(
-                listOf(record),
-                HistorySearchField.PACKAGE_NAME,
-                "installer",
-                texts
-            ).isEmpty()
+            filter(listOf(record), HistorySearchField.PACKAGE_NAME, "installer").isEmpty()
         )
         assertEquals(
             listOf(record),
-            filterHistoryRecords(listOf(record), HistorySearchField.INSTALLER_PACKAGE, "installer", texts)
+            filter(listOf(record), HistorySearchField.INSTALLER_PACKAGE, "installer")
         )
     }
 
@@ -58,59 +89,156 @@ class HistorySearchTest {
 
         assertEquals(
             listOf(first, second),
-            filterHistoryRecords(listOf(first, second), HistorySearchField.PACKAGE_NAME, "  ", texts)
+            filter(listOf(first, second), HistorySearchField.PACKAGE_NAME, "  ")
         )
     }
 
     @Test
-    fun `localized enum and time display values are searchable`() {
+    fun `raw enum values remain searchable`() {
         val record = record()
 
         assertEquals(
             listOf(record),
-            filterHistoryRecords(listOf(record), HistorySearchField.OPERATION_TYPE, "Install", texts)
+            filter(listOf(record), HistorySearchField.OPERATION_TYPE, "INSTALL")
         )
         assertEquals(
             listOf(record),
-            filterHistoryRecords(listOf(record), HistorySearchField.AUTHORIZER, "Root", texts)
-        )
-        assertEquals(
-            listOf(record),
-            filterHistoryRecords(listOf(record), HistorySearchField.TIME, "12:30", texts)
+            filter(listOf(record), HistorySearchField.AUTHORIZER, "root")
         )
     }
 
     @Test
-    fun `search empty state only applies when a nonblank query has no matches`() {
+    fun `visible unknown and none placeholders are searchable`() {
+        val incompleteRecord = record(
+            oldVersionName = null,
+            oldVersionCode = null,
+            newVersionName = "",
+            newVersionCode = null,
+            sourcePaths = emptyList(),
+            initiatorPackageName = null,
+            installerPackageName = null
+        )
+        val failedRecord = record(
+            id = 2L,
+            status = OperationStatus.FAILED,
+            errorType = null,
+            errorSummary = ""
+        )
+
+        assertEquals(
+            listOf(incompleteRecord),
+            filter(listOf(incompleteRecord), HistorySearchField.VERSION_NAME, "None")
+        )
+        assertEquals(
+            listOf(incompleteRecord),
+            filter(listOf(incompleteRecord), HistorySearchField.VERSION_CODE, "None")
+        )
+        assertEquals(
+            listOf(incompleteRecord),
+            filter(listOf(incompleteRecord), HistorySearchField.APK_PATH, "None")
+        )
+        assertEquals(
+            listOf(incompleteRecord),
+            filter(listOf(incompleteRecord), HistorySearchField.INITIATOR, "Unknown")
+        )
+        assertEquals(
+            listOf(incompleteRecord),
+            filter(listOf(incompleteRecord), HistorySearchField.INSTALLER_PACKAGE, "Unknown")
+        )
+        assertEquals(
+            listOf(failedRecord),
+            filter(listOf(failedRecord), HistorySearchField.ERROR, "Unknown")
+        )
+    }
+
+    @Test
+    fun `session records do not match fields hidden in their details`() {
+        val sessionRecord = record(
+            operationType = OperationType.SESSION_CONFIRM,
+            installMethod = InstallMethod.SESSION,
+            versionChange = VersionChange.UNKNOWN,
+            oldVersionName = null,
+            oldVersionCode = null,
+            newVersionName = null,
+            newVersionCode = null,
+            sourcePaths = emptyList()
+        )
+
+        assertTrue(filter(listOf(sessionRecord), HistorySearchField.VERSION_CHANGE, "Unknown").isEmpty())
+        assertTrue(filter(listOf(sessionRecord), HistorySearchField.VERSION_NAME, "None").isEmpty())
+        assertTrue(filter(listOf(sessionRecord), HistorySearchField.VERSION_CODE, "None").isEmpty())
+        assertTrue(filter(listOf(sessionRecord), HistorySearchField.APK_PATH, "None").isEmpty())
+        assertTrue(filter(listOf(sessionRecord), HistorySearchField.ALL, "Unknown").isEmpty())
+    }
+
+    @Test
+    fun `search result distinguishes no history from no matches`() {
         val records = listOf(record())
 
-        assertTrue(hasNoHistorySearchResults(records, "missing", emptyList()))
-        assertFalse(hasNoHistorySearchResults(emptyList(), "missing", emptyList()))
-        assertFalse(hasNoHistorySearchResults(records, "  ", emptyList()))
-        assertFalse(hasNoHistorySearchResults(records, "example", records))
+        assertEquals(
+            HistoryEmptyState.NO_HISTORY,
+            resolveHistorySearchResult(emptyList(), criteria("missing"), texts).emptyState
+        )
+        assertEquals(
+            HistoryEmptyState.NO_MATCHES,
+            resolveHistorySearchResult(records, criteria("missing"), texts).emptyState
+        )
+        assertEquals(
+            null,
+            resolveHistorySearchResult(records, criteria("example"), texts).emptyState
+        )
     }
+
+    @Test
+    fun `criteria is active for query or targeted field`() {
+        assertTrue(criteria("query").isActive)
+        assertTrue(HistorySearchCriteria(field = HistorySearchField.PACKAGE_NAME).isActive)
+        assertFalse(HistorySearchCriteria().isActive)
+    }
+
+    private fun filter(
+        records: List<OperationHistoryModel>,
+        field: HistorySearchField,
+        query: String
+    ) = filterHistoryRecords(records, HistorySearchCriteria(query, field), texts)
+
+    private fun criteria(query: String) = HistorySearchCriteria(query = query)
 
     private fun record(
         id: Long = 1L,
+        operationType: OperationType = OperationType.INSTALL,
         packageName: String = "com.example.app",
-        installerPackageName: String? = "com.example.installer"
+        installerPackageName: String? = "com.example.installer",
+        status: OperationStatus = OperationStatus.SUCCESS,
+        versionChange: VersionChange = VersionChange.UPDATE,
+        oldVersionName: String? = "1.0",
+        oldVersionCode: Long? = 1L,
+        newVersionName: String? = "2.0",
+        newVersionCode: Long? = 2L,
+        sourcePaths: List<String> = listOf("/tmp/example.apk"),
+        initiatorPackageName: String? = "com.example.source",
+        installMethod: InstallMethod = InstallMethod.PACKAGE_MANAGER,
+        errorSummary: String? = null,
+        errorType: String? = null
     ) = OperationHistoryModel(
         id = id,
-        operationType = OperationType.INSTALL,
-        status = OperationStatus.SUCCESS,
+        operationType = operationType,
+        status = status,
         packageName = packageName,
         appLabel = "Example App",
         timestamp = 1_755_330_600_000L,
-        versionChange = VersionChange.UPDATE,
-        oldVersionName = "1.0",
-        oldVersionCode = 1L,
-        newVersionName = "2.0",
-        newVersionCode = 2L,
-        sourcePaths = listOf("/tmp/example.apk"),
-        initiatorPackageName = "com.example.source",
+        versionChange = versionChange,
+        oldVersionName = oldVersionName,
+        oldVersionCode = oldVersionCode,
+        newVersionName = newVersionName,
+        newVersionCode = newVersionCode,
+        sourcePaths = sourcePaths,
+        initiatorPackageName = initiatorPackageName,
         installerPackageName = installerPackageName,
-        installMethod = InstallMethod.PACKAGE_MANAGER,
+        installMethod = installMethod,
         authorizer = Authorizer.Root,
-        installMode = InstallMode.Dialog
+        installMode = InstallMode.Dialog,
+        errorSummary = errorSummary,
+        errorType = errorType
     )
 }

--- a/app/src/test/java/com/rosan/installer/ui/page/main/settings/history/HistorySearchTest.kt
+++ b/app/src/test/java/com/rosan/installer/ui/page/main/settings/history/HistorySearchTest.kt
@@ -169,6 +169,8 @@ class HistorySearchTest {
         assertTrue(filter(listOf(sessionRecord), HistorySearchField.VERSION_CODE, "None").isEmpty())
         assertTrue(filter(listOf(sessionRecord), HistorySearchField.APK_PATH, "None").isEmpty())
         assertTrue(filter(listOf(sessionRecord), HistorySearchField.ALL, "Unknown").isEmpty())
+        assertFalse(sessionRecord.hasPackageManagerDetails())
+        assertTrue(record().hasPackageManagerDetails())
     }
 
     @Test
@@ -176,16 +178,16 @@ class HistorySearchTest {
         val records = listOf(record())
 
         assertEquals(
-            HistoryEmptyState.NO_HISTORY,
-            resolveHistorySearchResult(emptyList(), criteria("missing"), texts).emptyState
+            HistorySearchResult.Empty(HistoryEmptyState.NO_HISTORY),
+            resolveHistorySearchResult(emptyList(), criteria("missing"), texts)
         )
         assertEquals(
-            HistoryEmptyState.NO_MATCHES,
-            resolveHistorySearchResult(records, criteria("missing"), texts).emptyState
+            HistorySearchResult.Empty(HistoryEmptyState.NO_MATCHES),
+            resolveHistorySearchResult(records, criteria("missing"), texts)
         )
         assertEquals(
-            null,
-            resolveHistorySearchResult(records, criteria("example"), texts).emptyState
+            HistorySearchResult.Records(records),
+            resolveHistorySearchResult(records, criteria("example"), texts)
         )
     }
 


### PR DESCRIPTION
Add field-scoped history search to history page.

## Summary

Add searchable history records to both Material 3 and Miuix history pages.

Users can search across all record fields or select one specific field, such as package name, operation type, installer package name, or APK path.

## Behavior

- Add a search entry to the history page.
- Support searching all record fields by default.
- Support selecting a specific field before searching.

## UI Implementation

- Material 3 uses the native `ExposedDropdownMenu` and `DropdownMenuItem` components.
- Miuix uses the existing `MiuixDropdown` component.
- The Material 3 menu keeps a maximum height and supports scrolling for the complete field list.
- Both UI families share the same search semantics while preserving their existing component and styling conventions.

## File Responsibilities

- `HistorySearch.kt`
  - Defines searchable fields, localized labels, field value extraction, and filtering logic.
- `HistoryViewAction.kt`
  - Adds search query and field selection actions.
- `HistoryViewModel.kt`
  - Stores and updates search state.
- `HistoryViewState.kt`
  - Exposes the current query and selected field.
- `HistoryPage.kt`
  - Adds the Material 3 search controls and filtered history list.
- `MiuixHistoryPage.kt`
  - Adds the equivalent Miuix search controls and filtered history list.
- `strings.xml` and `values-zh-rCN/strings.xml`
  - Adds English and Simplified Chinese strings.
- `HistorySearchTest.kt`
  - Covers all-field search, field-specific search, package-name matching, localized values, and blank queries.


为历史页面添加字段限定的历史搜索

## 概述

为 Material 3 和 Miuix 历史页面添加可搜索的历史记录功能。

用户可以在所有记录字段中进行搜索，也可以选择特定字段进行搜索，例如包名、操作类型、安装包名称或 APK 路径。

## 行为

- 在历史页面添加搜索入口。
- 默认支持搜索所有记录字段。
- 支持在搜索前选择特定字段。

## UI 实现

- Material 3 使用原生 `ExposedDropdownMenu` 和 `DropdownMenuItem` 组件。
- Miuix 使用现有的 `MiuixDropdown` 组件。
- Material 3 下拉菜单保持最大高度，并支持滚动以显示完整的字段列表。
- 两套 UI 保留各自现有组件和样式规范，同时保持相同的搜索语义。

## 文件职责

- `HistorySearch.kt`
  - 定义可搜索字段、本地化标签、字段值提取和过滤逻辑。
- `HistoryViewAction.kt`
  - 添加搜索查询和字段选择操作。
- `HistoryViewModel.kt`
  - 存储和更新搜索状态。
- `HistoryViewState.kt`
  - 暴露当前查询内容和所选字段。
- `HistoryPage.kt`
  - 添加 Material 3 搜索控件和过滤后的历史记录列表。
- `MiuixHistoryPage.kt`
  - 添加对应的 Miuix 搜索控件和过滤后的历史记录列表。
- `strings.xml` 和 `values-zh-rCN/strings.xml`
  - 添加英文和简体中文字符串。
- `HistorySearchTest.kt`
  - 覆盖全字段搜索、字段限定搜索、包名匹配、本地化值以及空查询等测试场景。