### PR TITLE
fix: biometric auth on Android 8.x

### DIFF
--- a/app/src/main/keepRules/android-components.keep
+++ b/app/src/main/keepRules/android-components.keep
@@ -1,6 +1,9 @@
 # Keep Android IPC interfaces
 -keep public interface ** extends android.os.IInterface {*;}
 
+# Keep biometric classes for Android 8.x
+-keep class androidx.biometric.internal.FingerprintManagerCompat$Api* {*;}
+
 # Keep application entry point
 # -keep public class com.rosan.installer.App {*;}
 


### PR DESCRIPTION
Biometric authentication has been broken on Android 8.x devices since 64f57a7, as `android.hardware.fingerprint` was removed in API 37, causing R8 to strip the callback methods during release builds.

To temporarily fix this issue, this PR explicitly keeps the `FingerprintManagerCompat` internal classes in the keep rules to prevent method stripping.

This workaround can be safely reverted after the minSdk bump planned in #742.

Ref: https://issuetracker.google.com/issues/516212633