### PR TITLE
fix: fix ScaleNavTransition 's exitAnimation

### DIFF
--- a/app/src/main/java/com/rosan/installer/ui/animation/predictiveback/ScaleNavTransition.kt
+++ b/app/src/main/java/com/rosan/installer/ui/animation/predictiveback/ScaleNavTransition.kt
@@ -41,6 +41,7 @@ internal fun scaleNavTransition(exitDirection: PredictiveBackExitDirection): Nav
                         .coerceIn(0f, 1f)
 
                 scope.gesture != null -> 1f
+
                 else -> coverProgress(scope.relativeDepth)
             }
         },
@@ -102,8 +103,7 @@ internal fun scaleNavTransition(exitDirection: PredictiveBackExitDirection): Nav
     )
 }
 
-private fun shapedTopProgress(progress: Float, gesture: NavGesture?): Float =
-    if (gesture == null) progress else 1f - BackGestureEasing.transform((1f - progress).coerceIn(0f, 1f))
+private fun shapedTopProgress(progress: Float, gesture: NavGesture?): Float = if (gesture == null) progress else 1f - BackGestureEasing.transform((1f - progress).coerceIn(0f, 1f))
 
 private fun exitDirectionSign(
     direction: PredictiveBackExitDirection,
@@ -113,12 +113,12 @@ private fun exitDirectionSign(
         if (scope.gesture?.swipeEdge == NavSwipeEdge.Left) 1f else -1f
 
     PredictiveBackExitDirection.ALWAYS_RIGHT -> 1f
+
     PredictiveBackExitDirection.ALWAYS_LEFT -> -1f
 }
 
-private fun gesturePivotY(gesture: NavGesture?, height: Float): Float =
-    if (gesture != null && height > 0f) {
-        (gesture.touchY / height).coerceIn(0.1f, 0.9f)
-    } else {
-        0.5f
-    }
+private fun gesturePivotY(gesture: NavGesture?, height: Float): Float = if (gesture != null && height > 0f) {
+    (gesture.touchY / height).coerceIn(0.1f, 0.9f)
+} else {
+    0.5f
+}

--- a/app/src/main/java/com/rosan/installer/ui/animation/predictiveback/ScaleNavTransition.kt
+++ b/app/src/main/java/com/rosan/installer/ui/animation/predictiveback/ScaleNavTransition.kt
@@ -3,9 +3,8 @@
 package com.rosan.installer.ui.animation.predictiveback
 
 import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.ui.graphics.TransformOrigin
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.dp
 import com.rosan.installer.domain.settings.model.preferences.PredictiveBackExitDirection
 import top.yukonga.miuix.kmp.nav.transition.NavGesture
 import top.yukonga.miuix.kmp.nav.transition.NavMotion
@@ -19,11 +18,11 @@ import top.yukonga.miuix.kmp.nav.transition.NavTransitions
 import top.yukonga.miuix.kmp.nav.transition.navDirectionalTransition
 import top.yukonga.miuix.kmp.nav.transition.navGraphicsTransition
 
-private const val SCALE_MIN = 0.85f
-private val ScaleExitDrift = 96.dp
-
 private val ScaleExitMotion = NavMotion(
-    commit = NavSettleSpec.Tween(durationMillis = 450, easing = FastOutExtraSlowIn),
+    commit = NavSettleSpec.Tween(
+        durationMillis = 200,
+        easing = FastOutSlowInEasing,
+    ),
     cancel = NavSettleSpec.Spring(stiffness = 1500f),
     programmatic = NavSettleSpec.Tween(
         durationMillis = 200,
@@ -38,10 +37,10 @@ internal fun scaleNavTransition(exitDirection: PredictiveBackExitDirection): Nav
         scrim = { scope ->
             when {
                 scope.settle?.phase == NavSettlePhase.Commit ->
-                    (1f - (scope.settle?.elapsedMillis ?: 0f) / 450f).coerceIn(0f, 1f)
+                    (1f - (scope.settle?.elapsedMillis ?: 0f) / 200)
+                        .coerceIn(0f, 1f)
 
                 scope.gesture != null -> 1f
-
                 else -> coverProgress(scope.relativeDepth)
             }
         },
@@ -49,7 +48,6 @@ internal fun scaleNavTransition(exitDirection: PredictiveBackExitDirection): Nav
         val depth = scope.relativeDepth
         val widthPx = scope.layoutSize.width.toFloat()
         val heightPx = scope.layoutSize.height.toFloat()
-        val driftPx = with(scope.density) { ScaleExitDrift.toPx() }
         val gesture = scope.gesture
         val sign = exitDirectionSign(exitDirection, scope)
         val committing = scope.settle?.phase == NavSettlePhase.Commit
@@ -60,11 +58,11 @@ internal fun scaleNavTransition(exitDirection: PredictiveBackExitDirection): Nav
                 val releaseProgress = (1f - gesture.progress).coerceAtLeast(0.01f)
                 val post = (1f - progress / releaseProgress).coerceIn(0f, 1f)
                 val releaseEasedProgress = shapedTopProgress(releaseProgress, gesture)
-                val committedScale = SCALE_MIN + (1f - SCALE_MIN) * releaseEasedProgress
-                committedScale + (SCALE_MIN - committedScale) * post
+                val committedScale = 0.85f + (1f - 0.85f) * releaseEasedProgress
+                committedScale + (0.85f - committedScale) * post
             } else {
                 val easedProgress = shapedTopProgress(progress, gesture)
-                SCALE_MIN + (1f - SCALE_MIN) * easedProgress
+                0.85f + (1f - 0.85f) * easedProgress
             }
             val pivotX = if (gesture?.swipeEdge == NavSwipeEdge.Left) 0.8f else 0.2f
             val pivotY = gesturePivotY(gesture, heightPx)
@@ -79,7 +77,7 @@ internal fun scaleNavTransition(exitDirection: PredictiveBackExitDirection): Nav
             } else if (outgoingCommit) {
                 val releaseProgress = (1f - gesture.progress).coerceAtLeast(0.01f)
                 val post = (1f - progress / releaseProgress).coerceIn(0f, 1f)
-                sign * post * driftPx
+                sign * post * widthPx
             } else {
                 sign * (1f - progress) * widthPx
             }
@@ -95,10 +93,6 @@ internal fun scaleNavTransition(exitDirection: PredictiveBackExitDirection): Nav
                 extent = heightPx,
                 pivotFraction = pivotY,
             )
-            if (outgoingCommit) {
-                val elapsedMillis = scope.settle?.elapsedMillis ?: 0f
-                alpha = (1f - 5f * (elapsedMillis / 450f)).coerceAtLeast(0f)
-            }
         }
     }
     return navDirectionalTransition(
@@ -108,19 +102,23 @@ internal fun scaleNavTransition(exitDirection: PredictiveBackExitDirection): Nav
     )
 }
 
-private fun shapedTopProgress(progress: Float, gesture: NavGesture?): Float = if (gesture == null) progress else 1f - BackGestureEasing.transform((1f - progress).coerceIn(0f, 1f))
+private fun shapedTopProgress(progress: Float, gesture: NavGesture?): Float =
+    if (gesture == null) progress else 1f - BackGestureEasing.transform((1f - progress).coerceIn(0f, 1f))
 
-private fun exitDirectionSign(direction: PredictiveBackExitDirection, scope: NavTransitionScope): Float = when (direction) {
+private fun exitDirectionSign(
+    direction: PredictiveBackExitDirection,
+    scope: NavTransitionScope,
+): Float = when (direction) {
     PredictiveBackExitDirection.FOLLOW_GESTURE ->
         if (scope.gesture?.swipeEdge == NavSwipeEdge.Left) 1f else -1f
 
     PredictiveBackExitDirection.ALWAYS_RIGHT -> 1f
-
     PredictiveBackExitDirection.ALWAYS_LEFT -> -1f
 }
 
-private fun gesturePivotY(gesture: NavGesture?, height: Float): Float = if (gesture != null && height > 0f) {
-    (gesture.touchY / height).coerceIn(0.1f, 0.9f)
-} else {
-    0.5f
-}
+private fun gesturePivotY(gesture: NavGesture?, height: Float): Float =
+    if (gesture != null && height > 0f) {
+        (gesture.touchY / height).coerceIn(0.1f, 0.9f)
+    } else {
+        0.5f
+    }


### PR DESCRIPTION
When ScaleNavTransition migrate to miuix-nav
The exit animation wrongly change to AOSP like style

Lets rollback to old behavior to solve this problem